### PR TITLE
Cleanup the Azure docs a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-
-.idea/vcs.xml
-.idea/modules.xml
-.idea/misc.xml
-.idea/docs.iml
+.idea/

--- a/connector/code/azure.mdx
+++ b/connector/code/azure.mdx
@@ -9,10 +9,10 @@ Azure Repos is a set of version control tools for managing code offered as part 
 
 ## Setup
 1. From the PlayerZero web app, navigate to the home page.
-2. Select the Bitbucket connector under the Git Repository section
+2. Select the Azure Repo connector under the Git Repository section
 3. Submit the Azure DevOps Organization Name`https://dev.azure.com/{organization}`
 4. Submit the Azure DevOps Project `https://dev.azure.com/{organization}/{project}`
-5. Submit the [Personal Access Token (PAT)](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows): Make sure to enable ‘Read-code’ permissions
+5. Submit the [Personal Access Token (PAT)](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows): Make sure to enable `Read-code` and `Read & Write - Pull Request Threads` permissions. You may have to click "Show all scopes".
 6. Select the repositories you would like to connect to PlayerZero. This will pull in all historical changes and monitor for changes in code for this particular repo moving forward.
 
 <Note>


### PR DESCRIPTION
No longer reference bitbucket and clarify the permissions required. I'm still confused about how to handle the `project` setting better so leaving it alone for now.