### PR TITLE
Fix ticketing docs navigation path to include Context group

### DIFF
--- a/connector/azure-devops.mdx
+++ b/connector/azure-devops.mdx
@@ -40,7 +40,7 @@ Setup starts in PlayerZero—no pre-configuration in Azure DevOps is required.
 
 ### Step 1: Start the Connection
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Azure DevOps** in the available integrations list
 3. Click the **+** button to open the connection dialog
 

--- a/connector/confluence.mdx
+++ b/connector/confluence.mdx
@@ -57,7 +57,7 @@ PlayerZero requests only the permissions needed for AI agents to access and refe
 Setup starts in PlayerZero—no pre-configuration in Confluence is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Confluence** and click **Connect**
 3. You'll be redirected to Atlassian to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/freshdesk.mdx
+++ b/connector/freshdesk.mdx
@@ -43,7 +43,7 @@ PlayerZero requests only the permissions needed for AI agents to assist with sup
 Setup starts in PlayerZero — no pre-configuration in Freshdesk is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Freshdesk** and click **Connect**
 3. You'll be redirected to Freshdesk to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/hubspot.mdx
+++ b/connector/hubspot.mdx
@@ -62,7 +62,7 @@ PlayerZero requests only the permissions needed for AI agents to assist with cus
 Setup starts in PlayerZero—no pre-configuration in HubSpot is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **HubSpot** and click **Connect**
 3. You'll be redirected to HubSpot to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/intercom.mdx
+++ b/connector/intercom.mdx
@@ -41,7 +41,7 @@ Once connected, PlayerZero AI agents can:
 Setup starts in PlayerZero — no pre-configuration in Intercom is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Intercom** and click **Connect**
 3. You'll be redirected to Intercom to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/introduction.mdx
+++ b/connector/introduction.mdx
@@ -27,18 +27,18 @@ PlayerZero integrates with your existing stack through OAuth-based connections. 
 | [Zendesk](/connector/zendesk) | Support | Tickets, customer history |
 
 <Note>
-**Slack** is also available as a connector but is set up separately via **Settings → Collaboration** (not the Ticketing page). See [Slack](/connector/slack) for full details on capabilities, shortcuts, and setup.
+**Slack** is also available as a connector but is set up separately via **Settings → Collaboration** (not the Context → Ticketing page). See [Slack](/connector/slack) for full details on capabilities, shortcuts, and setup.
 </Note>
 
 <Note>
-**Remote MCP Servers** are also available for connecting external MCP-compatible services like Datadog or Coralogix. These are set up via **Settings → Context → MCP** (not the Ticketing page). See [Remote MCP Servers](/connector/remote-mcp-servers) for details.
+**Remote MCP Servers** are also available for connecting external MCP-compatible services like Datadog or Coralogix. These are set up via **Settings → Context → MCP** (not the Context → Ticketing page). See [Remote MCP Servers](/connector/remote-mcp-servers) for details.
 </Note>
 
 ## Setup
 
 All integrations follow the same process:
 
-1. Navigate to **Settings → Ticketing**
+1. Navigate to **Settings → Context → Ticketing**
 2. Find the integration and click **Connect**
 3. Authorize PlayerZero via OAuth
 4. Select which projects to enable

--- a/connector/jira.mdx
+++ b/connector/jira.mdx
@@ -43,14 +43,14 @@ PlayerZero requests only the permissions needed for AI agents to assist with deb
 Setup starts in PlayerZero—no pre-configuration in Jira is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Jira** and click **Connect**
 3. You'll be redirected to Jira to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration
 
 ## Using Jira from a Player Session
 
-Once Jira is connected via **Settings → Ticketing** and enabled for your project, AI Players can interact with Jira during any conversation or workflow stage. The Jira tools are automatically available — no additional configuration is needed.
+Once Jira is connected via **Settings → Context → Ticketing** and enabled for your project, AI Players can interact with Jira during any conversation or workflow stage. The Jira tools are automatically available — no additional configuration is needed.
 
 ### Creating Tickets
 
@@ -71,7 +71,7 @@ If a Player session was triggered from an existing Jira ticket (or you reference
 
 ### Comment Visibility
 
-Control whether AI agents post public or private comments on Jira issues. This is configured per integration from the Jira detail page in **Settings → Ticketing**.
+Control whether AI agents post public or private comments on Jira issues. This is configured per integration from the Jira detail page in **Settings → Context → Ticketing**.
 
 | Mode | Behavior |
 |---|---|
@@ -81,7 +81,7 @@ Control whether AI agents post public or private comments on Jira issues. This i
 
 To configure comment visibility:
 
-1. Navigate to the Jira integration detail page in **Settings → Ticketing**
+1. Navigate to the Jira integration detail page in **Settings → Context → Ticketing**
 2. Under **Comment visibility**, select a mode
 3. If you selected **Private comments only** or **Let the agent decide**, specify a **visibility role** (defaults to "Service Desk Team")
 

--- a/connector/linear.mdx
+++ b/connector/linear.mdx
@@ -52,7 +52,7 @@ PlayerZero requests only the permissions needed for AI agents to assist with deb
 Setup starts in PlayerZero—no pre-configuration in Linear is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Linear** and click **Connect**
 3. You'll be redirected to Linear to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/salesforce.mdx
+++ b/connector/salesforce.mdx
@@ -42,7 +42,7 @@ PlayerZero requests only the permissions needed for AI agents to assist with cus
 Setup starts in PlayerZero—no pre-configuration in Salesforce is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Salesforce** and click **Connect**
 3. You'll be redirected to Salesforce to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/servicenow.mdx
+++ b/connector/servicenow.mdx
@@ -43,7 +43,7 @@ PlayerZero requests access to ServiceNow via OAuth. The specific permissions dep
 Setup starts in PlayerZero—no pre-configuration in ServiceNow is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **ServiceNow** and click **Connect**
 3. You'll be redirected to ServiceNow to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration

--- a/connector/zendesk.mdx
+++ b/connector/zendesk.mdx
@@ -42,7 +42,7 @@ PlayerZero requests only the permissions needed for AI agents to assist with sup
 Setup starts in PlayerZero—no pre-configuration in Zendesk is required.
 </Note>
 
-1. In PlayerZero, navigate to **Settings → Ticketing**
+1. In PlayerZero, navigate to **Settings → Context → Ticketing**
 2. Find **Zendesk** and click **Connect**
 3. You'll be redirected to Zendesk to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration


### PR DESCRIPTION
Update all connector docs to reference "Settings → Context → Ticketing" instead of "Settings → Ticketing", matching the actual sidebar menu structure and consistent with how MCP docs already use "Settings → Context → MCP".