### PR TITLE
Add Microsoft Teams docs and update Slack integration page

### DIFF
--- a/connector/introduction.mdx
+++ b/connector/introduction.mdx
@@ -27,7 +27,7 @@ PlayerZero integrates with your existing stack through OAuth-based connections. 
 | [Zendesk](/connector/zendesk) | Support | Tickets, customer history |
 
 <Note>
-**Slack** is also available as a connector but is set up separately via **Settings → Collaboration** (not the Context → Ticketing page). See [Slack](/connector/slack) for full details on capabilities, shortcuts, and setup.
+**Slack** and **Microsoft Teams** are also available as connectors but are set up separately via **Settings → Collaboration** (not the Context → Ticketing page). See [Slack](/connector/slack) and [Microsoft Teams](/connector/microsoft-teams) for full details on capabilities and setup.
 </Note>
 
 <Note>

--- a/connector/microsoft-teams.mdx
+++ b/connector/microsoft-teams.mdx
@@ -1,0 +1,107 @@
+---
+title: "Microsoft Teams"
+description: "Connect Microsoft Teams to PlayerZero to interact with AI Players directly from Teams — start investigations, approve workflow stages, and receive notifications in channels."
+---
+
+Microsoft Teams is a collaboration platform from Microsoft. PlayerZero's Teams integration lets you interact with AI Players directly from Teams — starting investigations from channel conversations, approving workflow stage transitions, and receiving notifications alongside your team's work.
+
+## What You Can Do
+
+Once connected, you can:
+
+- **@mention or message the bot** — Mention the PlayerZero bot in any channel or send it a direct message to start a conversation. The bot responds with an interactive card to configure your investigation.
+- **Start investigations with Ask PlayerZero** — Select a project, choose a workflow or playbook, and provide your question. PlayerZero creates a Player session and responds in the thread.
+- **Approve workflow stage transitions** — When a Player needs approval to move to the next workflow stage, an interactive approval card appears in Teams with options to approve immediately or approve with a message and playbook.
+- **Receive notifications in channels** — Get workflow stage approval requests, Player summaries, and other notifications delivered to your team's channels.
+- **Open in Chat** — Link an existing PlayerZero session to a Teams channel from the PlayerZero UI, so you can continue a conversation in Teams.
+- **Reply in threads** — Continue a conversation with a Player by replying in the Teams thread. Messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+
+## Ask PlayerZero
+
+When you @mention or message the PlayerZero bot in a channel, the bot responds with an interactive **Ask PlayerZero** card. This card lets you configure your investigation before it starts.
+
+**For organizations with multiple projects**, the card starts with a project picker. Select your project and click **Continue** to load the compose form.
+
+**For single-project organizations**, the compose form appears directly.
+
+The compose form includes:
+
+- **Workflow** — Optionally select a workflow to start the Player in a specific workflow stage
+- **Playbook** — Optionally select a playbook to guide the Player's approach
+- **Message** — Describe your question or task
+
+Click **Ask** to create the Player session. PlayerZero responds in the thread with the Player's findings and a **Full Chat** link to the complete session in PlayerZero.
+
+If you @mention the bot in an existing thread, the initial message from that thread is automatically included as context for the Player.
+
+## Workflow Stage Approvals
+
+When an AI Player needs approval to move to the next workflow stage, PlayerZero delivers an approval card to Teams. These cards appear in the thread where the Player was started (if it originated from Teams) and in any channels configured for that workflow stage.
+
+The approval card includes:
+
+- An **Approve** button to approve the transition immediately
+- A **Playbook** picker to optionally select a playbook before approving
+- An **Approval message** field to add context or instructions
+- A **View in PlayerZero** link to open the full Player session
+
+After approval, a confirmation message is posted to the thread so the team can see who approved and any notes they included.
+
+## Open in Chat
+
+You can link any PlayerZero session to a Teams channel directly from the PlayerZero UI.
+
+From a Player session in PlayerZero, click **Open in Chat** and select a Teams channel. PlayerZero creates a new thread in that channel linked to the Player — messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+
+If the Player is already connected to a Teams thread, clicking **Open in Chat** takes you directly to that thread instead.
+
+## Receive Notifications
+
+PlayerZero delivers notifications to Teams channels based on your project and workflow configuration. Notifications include:
+
+- **Workflow stage approval requests** when a Player needs human approval to continue
+- **Player response summaries** posted to threads where investigations were started
+- **Notifications from monitor-initiated Players** when a monitor triggers a new investigation and delivers results to a configured channel
+
+Notification routing is configured per project and per workflow stage in **Settings**. See [Notification Configuration](#notification-configuration) for details.
+
+## Setup
+
+<Note>
+Setup starts in PlayerZero — no pre-configuration in Microsoft Teams is required. The Teams connection is managed under **Collaboration**, not the Ticketing page (which is used for tools like Jira and Linear). Connecting Teams requires Microsoft 365 admin consent.
+</Note>
+
+1. In PlayerZero, navigate to **Settings → Collaboration**
+2. Click the **Microsoft Teams** card to open its detail page
+3. Click **Enable** — a popup window will open for Microsoft admin consent authorization
+4. Sign in with a Microsoft 365 admin account and grant consent for your organization
+5. After authorization, a team picker appears — select which Teams to install the PlayerZero bot in
+6. Click **Install** to add the bot to the selected teams, or **Skip** to finish setup and install the bot later
+
+After setup, the PlayerZero bot is available in all channels within the teams you selected. You can add or remove teams at any time from the Collaboration settings page by clicking **Edit** on the Connection Details card.
+
+### Notification Configuration
+
+Once Teams is connected, you can configure where notifications are delivered at the organization and project level.
+
+**Organization-level defaults:**
+- Set a default Teams channel for notifications from the Collaboration settings page
+- Control which projects are authorized to use the Teams connection — either all projects or a specific set
+
+**Per-project, per-stage channels:**
+- Each project can configure notification channels independently
+- When selecting a channel, first choose a **team**, then select a **channel** within that team
+- Assign different channels to different workflow stages — for example, route approval requests to a support channel and engineering escalations to an engineering channel
+- Enable or disable workflow notifications (approval requests, stage transitions) per project
+
+**Business hours:**
+- Optionally restrict notifications to business hours based on your team's timezone
+- Notifications generated outside business hours are held and delivered when business hours resume
+
+## Get Started
+
+👉 [AI Player overview](/features/ai-player)
+
+👉 [Workflow overview](/features/workflows)
+
+👉 [Setup guide](/developer-guide/quickstart-guide)

--- a/connector/slack.mdx
+++ b/connector/slack.mdx
@@ -1,62 +1,88 @@
 ---
 title: "Slack"
-description: "Connect Slack to PlayerZero to interact with AI agents directly from Slack — trigger investigations from messages, chat in DMs, and route work into workflows."
+description: "Connect Slack to PlayerZero to interact with AI Players directly from Slack — start investigations from messages, run workflows, and receive notifications in channels."
 ---
 
-Slack is a messaging platform for teams. PlayerZero's Slack integration lets you interact with AI Players directly from Slack — starting investigations from message threads, chatting with agents in DMs, and routing incoming work into workflows.
+Slack is a messaging platform for teams. PlayerZero's Slack integration lets you interact with AI Players directly from Slack — starting investigations from message threads, chatting with Players in DMs, and running workflows with optional playbook guidance.
 
 ## What You Can Do
 
 Once connected, you can:
 
-- **Chat with AI Players in DMs** — Send messages directly to the PlayerZero bot to ask questions about your codebase, debug issues, or investigate problems
+- **Chat with Players in DMs** — Send messages directly to the PlayerZero bot to ask questions about your codebase, debug issues, or investigate problems
 - **@mention in channels** — Mention the PlayerZero bot in any channel to start a conversation. The bot creates a Player session and responds in a thread.
-- **Trigger investigations from messages** — Use Slack message shortcuts to send any message thread to a PlayerZero AI Player, with full thread context automatically captured
-- **Route work into workflows** — Use the "Add to Backlog" shortcut to send Slack threads into a specific workflow stage for structured processing
-- **Receive alerts in channels** — Get real-time notifications for issue clusters, anomaly spikes, and deployments delivered to your team's channels
+- **Start investigations from messages** — Use the **Ask PlayerZero** message shortcut to send any message thread to a Player, with full thread context automatically captured and optional workflow or playbook selection
+- **Use the `/ask_playerzero` command** — Type `/ask_playerzero` in any channel to open the Ask PlayerZero modal without needing to right-click a message
+- **Open in Chat** — Link an existing PlayerZero session to a Slack channel from the PlayerZero UI, so you can continue a conversation in Slack
+- **Receive notifications in channels** — Get workflow stage approval requests, Player summaries, and other notifications delivered to your team's channels
 
-## Message Shortcuts
+## Ask PlayerZero
 
-PlayerZero adds two message shortcuts to Slack. Right-click any message (or use the ⋯ menu) to access them.
+### Message Shortcut
 
-### Add to Backlog
+Right-click any message (or use the ⋯ menu) and select **Ask PlayerZero** to send it to a PlayerZero AI Player.
 
-Sends a Slack message and its thread context into a PlayerZero workflow.
-
-1. Select **Add to Backlog** from the message shortcut menu
+1. Select **Ask PlayerZero** from the message shortcut menu
 2. Choose a **project** (if you have more than one)
-3. Choose a **workflow entry stage** — the Player will start processing from this stage, or select **Ask** for a freeform conversation
+3. Optionally select a **workflow** to start the Player in a specific workflow stage, or a **playbook** to guide the Player's approach
 4. Add any **additional context** to supplement the thread content
 5. Click **Create**
 
 PlayerZero automatically reads the original thread and includes it as context for the AI Player. The Player session is linked back to the Slack thread — a summary of the agent's response appears in the thread with a **Full Chat** link to the complete session in PlayerZero. Messages you send in the thread are forwarded to the Player.
 
-### Ask PlayerZero
+You can preview the instructions for a selected workflow or playbook using the **Preview** button before submitting.
 
-Sends a Slack message and its thread context to a PlayerZero AI Player for a freeform conversation.
+### Slash Command
 
-1. Select **Ask PlayerZero** from the message shortcut menu
-2. Choose a **project** (if you have more than one)
-3. Add any **additional context**
-4. Click **Create**
+Type `/ask_playerzero` in any channel to open the same Ask PlayerZero modal directly. Any text you include after the command is pre-filled into the message field.
 
-This works the same as "Add to Backlog" but without workflow stage selection — the Player starts a freeform conversation using the thread context as its starting point.
+The command creates a new thread in the current channel and links it to the Player session. This is useful when you want to start an investigation without a specific message to reference.
 
-### New Backlog (Global Shortcut)
+### Global Shortcut
 
-Creates a new PlayerZero backlog item without message context. Access this from Slack's global shortcuts menu.
+Open Slack's global shortcuts menu and select **Ask PlayerZero** to start a new Player session without message context.
 
 1. Open the global shortcuts menu
-2. Select **New Backlog**
-3. Choose a **project** and **workflow entry stage**
-4. Provide **context** describing the work
+2. Select **Ask PlayerZero**
+3. Choose a **project** and optionally a **workflow** or **playbook**
+4. Provide a **message** describing your question or task
 5. Click **Create**
 
-Unlike the message shortcuts, this does not capture thread context — use it when you want to create a new item from scratch.
+Unlike the message shortcut, this does not capture thread context — use it when you want to start a new investigation from scratch. The Player session opens in a DM with the PlayerZero bot.
 
 ### How Thread Context Works
 
-When you trigger either message shortcut from a message that's part of a thread, PlayerZero reads the parent message of that thread and includes its content alongside your additional context. This means the AI Player understands the full conversation without you needing to copy and paste.
+When you trigger the message shortcut from a message that's part of a thread, PlayerZero reads the parent message of that thread and includes its content alongside your additional context. This means the AI Player understands the full conversation without you needing to copy and paste.
+
+## Workflow Stage Approvals
+
+When an AI Player needs approval to move to the next workflow stage, PlayerZero delivers an approval notification to Slack. These notifications appear in the thread where the Player was started (if it originated from Slack) and in any channels configured for that workflow stage.
+
+The notification includes:
+
+- An **Approve** button to approve the transition immediately
+- An **Approve with message** button to add context, select a playbook, or provide instructions before approving
+- A **View in PlayerZero** link to open the full Player session
+
+After approval, a confirmation message is posted to the thread so the team can see who approved and any notes they included.
+
+## Open in Chat
+
+You can link any PlayerZero session to a Slack channel directly from the PlayerZero UI.
+
+From a Player session in PlayerZero, click **Open in Chat** and select a Slack channel. PlayerZero creates a new thread in that channel linked to the Player — messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+
+If the Player is already connected to a Slack thread, clicking **Open in Chat** takes you directly to that thread instead.
+
+## Receive Notifications
+
+PlayerZero delivers notifications to Slack channels based on your project and workflow configuration. Notifications include:
+
+- **Workflow stage approval requests** when a Player needs human approval to continue
+- **Player response summaries** posted to threads where investigations were started
+- **Notifications from monitor-initiated Players** when a monitor triggers a new investigation and delivers results to a configured channel
+
+Notification routing is configured per project and per workflow stage in **Settings**. See [Notification Configuration](#notification-configuration) for details.
 
 ## Scopes & Permissions
 
@@ -68,15 +94,16 @@ PlayerZero requests only the permissions needed for AI agents to assist with deb
 |-------|-----------------|
 | `app_mentions:read` | **@mention responses** — Allows PlayerZero to detect when someone mentions the bot in a channel and respond |
 | `channels:history` | **Thread context** — Enables reading message threads to provide full context when a shortcut is triggered from a channel |
-| `channels:join` | **Channel access** — Allows the bot to join channels where it needs to deliver alerts or respond to mentions |
-| `channels:read` | **Channel discovery** — Lets PlayerZero list available channels during setup so you can choose where to receive alerts |
-| `chat:write` | **Responses and alerts** — Enables sending agent responses, investigation results, and alert notifications |
+| `channels:join` | **Channel access** — Allows the bot to join public channels where it needs to deliver notifications or respond to mentions |
+| `channels:read` | **Channel discovery** — Lets PlayerZero list available channels during setup so you can choose where to receive notifications |
+| `chat:write` | **Responses and notifications** — Enables sending agent responses, investigation results, and approval notifications |
 | `chat:write.customize` | **Attributed messages** — Allows the bot to send messages on behalf of team members (e.g., "Alice (via PlayerZero)") when relaying messages from the PlayerZero UI |
-| `commands` | **Shortcuts** — Required for the "Add to Backlog" and "Ask PlayerZero" message shortcuts |
+| `commands` | **Slash command and shortcuts** — Required for the `/ask_playerzero` command and the Ask PlayerZero shortcuts |
 | `files:write` | **File sharing** — Enables sharing files (e.g., diagrams, reports) generated by AI agents |
 | `groups:history` | **Private channel threads** — Same as `channels:history` but for private channels |
 | `groups:read` | **Private channel info** — Same as `channels:read` but for private channels |
-| `im:history` | **DM conversations** — Enables reading and responding to direct messages with the bot |
+| `im:history` | **DM conversations** — Enables reading direct messages with the bot |
+| `im:write` | **DM initiation** — Enables the bot to open direct message conversations |
 | `mpim:history` | **Group DM conversations** — Enables participating in group direct message threads |
 | `users:read` | **User mapping** — Allows matching Slack users to PlayerZero accounts for proper attribution |
 | `users:read.email` | **Email matching** — Uses email addresses to link Slack identities with PlayerZero user accounts |
@@ -93,6 +120,14 @@ Setup starts in PlayerZero — no pre-configuration in Slack is required. The Sl
 4. Sign in to Slack and authorize PlayerZero in your workspace
 5. After authorization, the popup closes and you'll see the Slack detail page with configuration options
 
+Once connected, all Slack capabilities are immediately available — the `/ask_playerzero` command, message shortcuts, DMs with the bot, and @mention responses. No additional configuration is needed beyond the initial connection.
+
+### Channel Access
+
+The PlayerZero bot automatically joins public channels when it needs to deliver a notification or respond to a mention. No manual invitation is required for public channels.
+
+For **private channels**, you need to manually invite the bot by typing `/invite @PlayerZero` in the channel before PlayerZero can post there.
+
 ### Notification Configuration
 
 Once Slack is connected, you can configure where notifications are delivered at the organization and project level.
@@ -103,14 +138,12 @@ Once Slack is connected, you can configure where notifications are delivered at 
 
 **Per-project, per-stage channels:**
 - Each project can configure notification channels independently
-- Assign different Slack channels to different workflow stages — for example, route triage notifications to `#support-triage` and engineering escalations to `#eng-alerts`
+- Assign different Slack channels to different workflow stages — for example, route approval requests to `#support-triage` and engineering escalations to `#eng-alerts`
 - Enable or disable workflow notifications (approval requests, stage transitions) per project
 
 **Business hours:**
 - Optionally restrict notifications to business hours based on your team's timezone
 - Notifications generated outside business hours are held and delivered when business hours resume
-
-Once connected, all Slack capabilities are immediately available — message shortcuts ("Add to Backlog", "Ask PlayerZero", and "New Backlog"), DMs with the bot, and @mention responses. No additional configuration is needed beyond the initial connection.
 
 ## Get Started
 

--- a/docs.json
+++ b/docs.json
@@ -70,6 +70,7 @@
                   "connector/intercom",
                   "connector/jira",
                   "connector/linear",
+                  "connector/microsoft-teams",
                   "connector/salesforce",
                   "connector/servicenow",
                   "connector/slack",


### PR DESCRIPTION
Introduce a new Microsoft Teams page covering setup, Ask PlayerZero cards, workflow approvals, and notification configuration. Update the Slack page to reflect the new Ask PlayerZero experience, the slash command, workflow stage approvals, and Open in Chat.