### PR TITLE
Remove beta tag from API Triggers docs page

### DIFF
--- a/features/additional-features/api-triggers.mdx
+++ b/features/additional-features/api-triggers.mdx
@@ -2,12 +2,7 @@
 title: "API Triggers"
 sidebarTitle: "API Triggers"
 description: "Allow external systems to start PlayerZero workflows by calling an HTTP endpoint."
-tag: "beta"
 ---
-
-<Note>
-API Triggers is currently in **beta**. Features and behavior may change as we refine the experience.
-</Note>
 
 ## What Are API Triggers?
 


### PR DESCRIPTION
API Triggers is now generally available. Remove the beta sidebar badge and the beta disclaimer note.