### PR TITLE
docs: weekly update (2026-05-18 to 06-03) + Channels & Branches pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -140,6 +140,7 @@
                 "pages": [
                   "features/ai-player",
                   "features/hive-mode",
+                  "features/channels",
                   "features/playbooks"
                 ]
               },

--- a/features/additional-features/api-triggers.mdx
+++ b/features/additional-features/api-triggers.mdx
@@ -6,7 +6,7 @@ description: "Allow external systems to start PlayerZero workflows by calling an
 
 ## What Are API Triggers?
 
-API Triggers let external systems — such as CI/CD pipelines, monitoring tools, or internal scripts — start PlayerZero workflows by sending an HTTP POST request to a unique endpoint. Each trigger is mapped to a specific workflow stage, so when the endpoint is called, a new Player session is created and begins processing from that stage.
+API Triggers let external systems — such as CI/CD pipelines, monitoring tools, or internal scripts — start PlayerZero workflows by sending an HTTP POST request to a unique endpoint. Each trigger is mapped to a specific **workflow**, so when the endpoint is called, a new Player session is created and begins processing from that workflow's entry point.
 
 Trigger configuration is managed at the **organization level**. Navigate to **Settings → API Triggers** to view and manage them.
 
@@ -22,7 +22,7 @@ Trigger configuration is managed at the **organization level**. Navigate to **Se
 |---|---|
 | **Name** | A short, descriptive name (e.g., "Deploy Pipeline Trigger"). Must be at least 3 characters. |
 | **Description** | *(Optional)* Explain what this trigger does or when it fires. |
-| **Workflow stage** | The project and entry stage to run when this trigger fires. |
+| **Workflow** | The project and workflow to run when this trigger fires. The Player starts at the workflow's entry point. |
 | **HMAC validation** | *(Optional)* Enable HMAC signature verification to authenticate incoming requests. See [Security](#security) below. |
 | **CIDR blocks** | *(Optional)* Restrict which IP addresses can call the trigger. See [Security](#security) below. |
 | **Active** | Enable or disable the trigger. Inactive triggers reject all incoming requests. |
@@ -111,7 +111,7 @@ When no CIDR blocks are configured, requests are accepted from any IP address.
 
 The triggers page shows all triggers in your organization in a split-panel view:
 
-- **Left panel** — A list of all triggers, each showing the name, description, mapped workflow stage, endpoint URL, and run count (last 24 hours)
+- **Left panel** — A list of all triggers, each showing the name, description, mapped **workflow**, endpoint URL, and run count (last 24 hours)
 - **Right panel** — Detailed view of the selected trigger, including full configuration, security settings, and error status
 
 ### Trigger Detail
@@ -119,7 +119,7 @@ The triggers page shows all triggers in your organization in a split-panel view:
 Click any trigger in the list to open its detail panel. The detail view shows:
 
 - **Endpoint URL** — The full URL to call, with a copy button
-- **Workflow stage** — The project and stage that runs when the trigger fires
+- **Workflow** — The project and workflow that runs when the trigger fires
 - **HMAC validation** — Signature header, algorithm, encoding, prefix, and masked secret (if configured)
 - **Runs (24h)** — Number of successful invocations in the last 24 hours
 - **CIDR blocks** — Configured IP ranges (if any)
@@ -128,7 +128,7 @@ Click any trigger in the list to open its detail panel. The detail view shows:
 
 1. Select a trigger from the list
 2. Click **Edit** in the detail panel footer
-3. Update any fields — name, description, workflow stage, security settings, or active status
+3. Update any fields — name, description, **workflow**, security settings, or active status
 4. Click **Save**
 
 ### Activating and Deactivating
@@ -164,7 +164,7 @@ When a trigger endpoint is called:
 1. **Authentication** — The trigger token is validated and the trigger must be active
 2. **Security checks** — CIDR and HMAC validation are applied (if configured)
 3. **Payload storage** — The request body is stored securely
-4. **Workflow creation** — A new Player session is created and starts processing from the configured workflow stage, with the request body as context
+4. **Workflow creation** — A new Player session is created and starts processing from the configured **workflow's entry point**, with the request body as context
 5. **Cleanup** — The stored payload is deleted after the Player session is created
 
 Players created by API Triggers are labeled with an **API Trigger** origin in the workflow inbox, making them easy to identify and track.

--- a/features/additional-features/chrome-extension.mdx
+++ b/features/additional-features/chrome-extension.mdx
@@ -6,7 +6,7 @@ description: "Bring PlayerZero's AI Player directly into your browser. Capture a
 
 ## What Is the Chrome Extension?
 
-The PlayerZero Chrome Extension puts the **AI Player** right inside your browser. Instead of switching tabs to start an investigation, you can capture the page you're looking at, ask a question, or kick off a workflow stage — all from a lightweight side panel that lives alongside the page you're working on.
+The PlayerZero Chrome Extension puts the **AI Player** right inside your browser. Instead of switching tabs to start an investigation, you can capture the page you're looking at, ask a question, or kick off a workflow — all from a lightweight side panel that lives alongside the page you're working on.
 
 It's designed for anyone who triages issues, reviews customer-facing pages, or investigates bugs and wants to get AI-powered answers without breaking their flow.
 
@@ -60,14 +60,14 @@ Once you've optionally captured page context, you can start an AI Player session
 </Accordion>
 
 <Accordion title="Workflow Mode">
-- **What it does:** Start a structured workflow stage instead of a free-form question.
-- **How to use:** Select an **Entry stage** from the dropdown above the text box, then submit. You can optionally include a question or page context.
+- **What it does:** Start a structured workflow instead of a free-form question. The Player begins at the workflow's entry point.
+- **How to use:** Select a **workflow** from the dropdown above the text box, then submit. You can optionally include a question or page context.
 - **Best for:** Repeatable processes like bug triage, code review prep, or customer issue investigation.
 </Accordion>
 
 <Accordion title="Quick Start">
 - **What it does:** One-click workflow launch that automatically captures the current page as context.
-- **How to use:** Click any **Quick Start button** below the input area. The extension captures the current page and immediately starts the selected workflow stage.
+- **How to use:** Quick Start shows one button per workflow ("Start <workflow>") below the input area. Click any button to capture the current page and immediately start that workflow.
 - **Best for:** When you want to jump straight into a workflow with the current page as context — no typing required.
 </Accordion>
 
@@ -99,7 +99,7 @@ The side panel includes a **backlog view** so you can track all your active AI P
 </Accordion>
 
 <Accordion title="Workflow Tab">
-- Shows **Workflow Players** grouped into three categories:
+- Shows **Workflow Players** grouped into three categories (each Player is labeled with its current stage):
   - **Needs Input** — Players waiting for your response or action
   - **In Progress** — Players currently running
   - **Done** — Completed Players

--- a/features/additional-features/usage-analytics.mdx
+++ b/features/additional-features/usage-analytics.mdx
@@ -62,14 +62,14 @@ Tracks code simulation activity.
 
 ### Workflows
 
-Tracks workflow stage activity for the selected project.
+Tracks workflow activity for the selected project, summarized per workflow.
 
 <Note>
 Workflow data is only available when viewing a specific project — it does not aggregate across projects.
 </Note>
 
-- **Stage metrics table** — Per-stage breakdown of issues processed, issues transitioned, questions asked, and simulations run
-- **Workflow graph** — Visual representation of workflow activity overlaid on your stage graph
+- **Workflow metrics table** — One row per workflow showing questions asked, simulations run, and stage transitions in the selected time range.
+- **Workflow graph** — A visual map of your project's workflows with activity reflected on each workflow.
 
 Toggle between **table** and **graph** views using the tabs.
 
@@ -107,7 +107,7 @@ Export usage data as a CSV file for external reporting, audits, or analysis.
 | Active Unique Users (Ranked) | Users ranked by question count |
 | Active Users by Role | Estimated unique users per job role |
 | Total Codesims Run | Simulation count with breakdown by scenario type and system layer |
-| Workflow Stages | Per-stage metrics: issues processed, transitioned, questions asked, simulations run |
+| Workflows | Per-workflow metrics: questions asked, simulations run, and stage transitions |
 | Artifacts Created / Shared | Artifact creation and sharing counts |
 | Lines of Code Used | Lines of code analyzed and total processed |
 

--- a/features/ai-player.mdx
+++ b/features/ai-player.mdx
@@ -170,6 +170,7 @@ Generate structured content to support issue tracking:
 ## Get Started
 
 - [Hive Mode](/features/hive-mode) — Deploy teams of specialist agents for complex investigations
+- [Channels & Multiplayer](/features/channels) — Work with multiple Players in a shared, channel-first workspace
 - [Playbooks](/features/playbooks) — Create and reuse prompt templates across your team
 - [Code Simulations](/features/code-sim) — Test scenarios through AI-powered code simulation
 - [Usage Analytics](/features/additional-features/usage-analytics) — Track questions, simulations, and team activity

--- a/features/channels.mdx
+++ b/features/channels.mdx
@@ -1,0 +1,91 @@
+---
+title: "Channels & Multiplayer"
+sidebarTitle: "Channels"
+description: "Work with multiple AI Players side by side in a shared, channel-first workspace — with a Player roster, live sandbox output, file citations, and workflow entry."
+---
+
+## What Is a Channel?
+
+A **channel** is PlayerZero's full-screen workspace for working with one or more AI Players in a shared context. Every Player conversation — a **thread** — lives inside a channel, and a single channel can hold many threads that share context with one another.
+
+PlayerZero is channel-first: you start a channel, and your threads live inside it. If you try to start a new thread while you're not in a channel, PlayerZero reminds you that **threads live in channels now** and points you back to your home page to start one.
+
+The channel workspace has four main areas:
+
+- A **title bar** showing the active thread's title and the channel name
+- A **Player roster** on the left listing every thread in the channel
+- The **active thread** in the center, where you converse with the Player and watch its work
+- A **status panel** on the right with details about the active Player
+
+---
+
+## The Player Roster
+
+The left column lists every Player (thread) in the channel so multiple people — and multiple Players — can work in parallel without losing the shared context.
+
+- **Start a new thread** — Click **New Thread** at the top of the roster, or press **⌘K** / **Ctrl+K** while you're in a channel. New threads can share context from the channel.
+- **Switch threads** — Click any row to open that Player in the center pane.
+- Each row shows the thread's **title**, **avatars** of the people involved, and an **activity indicator** — a spinner while the Player is running, or how long ago it was last active.
+- Threads that belong to a workflow are **grouped under the workflow's name**.
+- When a Player has produced **artifacts** (documents, diagrams, reports), expand its row to see and open them directly.
+
+<Note>
+Starting a new thread from inside a channel doesn't prompt you to pick a workflow — in-channel threads are free-form and inherit the channel's context. To run a workflow in the channel, use **Enter a workflow** (below).
+</Note>
+
+---
+
+## Entering a Workflow
+
+A channel can run a [workflow](/features/workflows). Users with **editor** access use **Enter a workflow** in the roster to start one; the Player begins at the workflow's entry point.
+
+When a Player is ready to advance, the request appears in the roster as a **Workflow approval** that an editor can **Approve**. Reviewers aren't limited to the agent's suggested step — see [two-way approvals](/features/workflow-inbox#inline-approval) for how a reviewer can redirect to another stage or workflow.
+
+If an approval waits without action, PlayerZero can notify your team through a connected **Slack** or **Microsoft Teams** integration with a **Stage Approval Required** message and buttons to **Approve**, **Approve with message**, or **View in PlayerZero**.
+
+---
+
+## Watching a Player Work
+
+Threads stream the Player's work as it happens.
+
+### Live Sandbox Output
+
+When a Player runs a command in its sandbox, the message shows the **Code** it ran and the **Output**, streaming in as the command executes. You'll see a **running...** status while a command is in flight and an **exit** code when it finishes — with **Waiting for output...** before the first output arrives, or **No output** if the command produced none.
+
+### File Citations
+
+When a Player references a file, it appears as a clickable **citation**. Click an inline citation to open the file in an in-app viewer tab, jumping to the cited line when one is given. Larger, block-style citations can also be **downloaded** directly.
+
+---
+
+## Human-in-the-Loop Questions
+
+A Player can pause and ask a person for input rather than guessing. When it does, the question appears in the thread for you to answer:
+
+- Provide your responses and click **Submit Answers** to let the Player continue. Every question needs a response first.
+- Use **Skip** or **Continue** to move through individual questions.
+- Reassign a question to a teammate — each question shows **"Assigned to {name}. Click to reassign."** with a teammate search.
+
+---
+
+## Renaming a Channel
+
+New channels start as **Untitled Channel**. Click the channel name in the title bar (**Rename channel**) to edit it inline. Channel names are limited to **70 characters**. Any member with access to the channel — including viewers — can rename it.
+
+---
+
+## Relationship to Hive Mode and Workflows
+
+- **[Hive Mode](/features/hive-mode)** is chosen per thread when you create it, using the **Agent** / **Hive** toggle. It controls whether a single agent or a coordinated team of specialists works that thread — it's independent of the channel itself.
+- **[Workflows](/features/workflows)** run inside a channel. Enter one from the roster, then manage and approve transitions there or in the [Workflow Inbox](/features/workflow-inbox).
+
+---
+
+## Get Started
+
+👉 [AI Player overview](/features/ai-player)
+
+👉 [Hive Mode](/features/hive-mode)
+
+👉 [Workflows overview](/features/workflows)

--- a/features/code-reviews.mdx
+++ b/features/code-reviews.mdx
@@ -102,9 +102,24 @@ Any team member with **viewer** access or higher can start a PR review session. 
 
 ## Automatic Monitors on Merge
 
-When a PR is merged, PlayerZero can automatically generate regression monitors that watch for issues introduced by the merged changes. These monitors target existing telemetry signals and are posted as a comment on the merged PR.
+When a PR is merged into your repository's **release branch**, PlayerZero can automatically generate regression monitors that watch for issues introduced by the merged changes. These monitors target existing telemetry signals and are posted as a comment on the merged PR.
 
 For details on how proactive monitors work and how to manage them, see [Monitors → Proactive Monitors](/features/monitors#proactive-monitors).
+
+## Branches
+
+The **Branches** list gives you a project-wide view of active branches and their review status. Open it from **Branches** in the project sidebar; each row links to that branch's review page.
+
+Each row shows:
+
+- The **repository and branch name** — and, when the branch has an associated pull request, the **PR status** (Active, Merged, or Abandoned) and the **PR title**.
+- A **Last Commit** column summarizing review state: a simulation-status dot with a passed ratio (for example, "3/4 passed") when simulations have run, avatars of the contributors involved, and how long ago the branch was last updated.
+
+You can:
+
+- **Sort** by **Recently Updated** or **Least Recently Updated**.
+- **Search** branches — a branch matches if **either** its branch name **or** its associated PR title matches your query.
+- **Filter** by repository, by PR status (**Any PR Status**, **Active**, **Merged**, **Abandoned**), and by scope (**Everyone's Branches** or **My Branches**).
 
 ## Get Started
 

--- a/features/code-sim.mdx
+++ b/features/code-sim.mdx
@@ -83,7 +83,8 @@ Run scenarios through AI-powered simulation — no actual code execution require
   - Your codebase
   - Historical failure patterns
   - Known dependencies and system behavior
-- Simulations run against your organization's configured **release branch** by default. You can select a different branch when launching a simulation.
+- Simulations run against your organization's configured **release branch** by default, and you can select a different branch when launching a simulation.
+- When you launch a simulation from within a Player session, it inherits that Player's **current repo and branch selection** and any **uncommitted edits in the Player's sandbox** — so the simulation runs against the code context you're actively working in, not a snapshot from when the Player was created.
 </Accordion>
 
 <Accordion title="Status Tracking">
@@ -174,3 +175,5 @@ Code Simulations transform testing by providing **intelligent pre-analysis**, al
 ## Get Started
 
 👉 [Setup guide](/developer-guide/quickstart-guide)
+
+👉 [AI Player overview](/features/ai-player)

--- a/features/configuring-workflows.mdx
+++ b/features/configuring-workflows.mdx
@@ -52,6 +52,8 @@ Transitions define the allowed paths between stages.
 
 In the workflow builder, draw a connection from one stage to another. A dialog will prompt you to describe the transition conditions — the rules that tell the agent when to take this path.
 
+On an existing stage, adding, updating, or removing a transition saves automatically — there's no separate save step. (Creating a brand-new stage still uses an explicit **Save**.)
+
 ### Transition Conditions
 
 Each transition includes an instruction field. Write specific conditions, not vague ones:
@@ -60,6 +62,15 @@ Each transition includes an instruction field. Write specific conditions, not va
 - **Avoid**: "Move to the next stage when ready."
 
 The agent uses these conditions to decide which transition to request.
+
+### Transition Targets
+
+A transition can point to either:
+
+- **A stage in the same workflow** — the default. Work continues within the current workflow.
+- **Another workflow's entry** — work hands off to a different workflow in the same project, which begins at its entry point. Use this to chain workflows together — for example, routing a completed triage into a separate remediation workflow.
+
+Cross-workflow transitions use the same instruction-based conditions and approval behavior as in-workflow transitions: the agent evaluates the condition and requests the transition when it's met.
 
 ---
 
@@ -139,6 +150,35 @@ When conflicts are found, all are initially set to Merge. You can change individ
 
 Stages that don't conflict with existing names are imported automatically without prompting.
 
+#### Importing Stages from Another Workflow
+
+In addition to importing from a JSON file, you can import stages directly from **another workflow** — in the current project **or a different project in your organization**. PlayerZero lists that workflow's stages so you can select exactly the ones you want to bring in. The selected stages are added to your workflow.
+
+#### Importing into an Existing Workflow
+
+You can import stages into an existing workflow rather than only creating a new one. Select the specific stages you want to bring in (from another workflow or from a JSON file). How the import lands depends on the target:
+
+- **Published workflow** — the import creates a new **draft** of the workflow with the imported stages added to the existing ones. Publishing the draft makes the change live.
+- **Draft workflow** — the imported stages are added to the existing draft.
+
+---
+
+## Versions & Drafts
+
+A workflow has a **published version** — the live definition that Players run against — and can have an editable **draft**. Drafts let you change stages, transitions, and rules without affecting work that's already in flight.
+
+### Editing as a Draft
+
+You can create a **draft** of a published workflow to change stages, transitions, and rules without affecting Players already running against the published version. Publishing the draft makes it the new published version.
+
+### Starting a Player Against a Draft
+
+You can start — or fork — a Player against a specific draft version so you can test changes before publishing. Players running on a draft are shown with a **draft** label so it's clear they aren't using the published definition.
+
+<Note>
+Access to start or fork Players against a draft is limited to the draft's creator, users on its visibility list, or users whose organization job role is on that list — and always requires editor or owner permissions.
+</Note>
+
 ---
 
 ## The Workflow Inbox
@@ -149,4 +189,4 @@ The inbox is the operational view for managing active Players across your workfl
 
 ## Related
 
-- [Monitors](/features/monitors) — Set up automated checks that can trigger workflow stages on failure
+- [Monitors](/features/monitors) — Set up automated checks that can trigger a workflow on failure

--- a/features/hive-mode.mdx
+++ b/features/hive-mode.mdx
@@ -145,4 +145,6 @@ In the chat stream, you'll see:
 
 👉 [AI Player overview](/features/ai-player)
 
+👉 [Channels & Multiplayer](/features/channels)
+
 👉 [Setup guide](/developer-guide/quickstart-guide)

--- a/features/knowledge-bases.mdx
+++ b/features/knowledge-bases.mdx
@@ -43,10 +43,9 @@ Once a group exists, upload documents to it:
 2. Click **Upload Document**
 3. Select a file from your computer
 
-**Supported formats:** `.txt`, `.md`, `.csv`
-**Maximum file size:** 4 MB per document
+**Accepted:** Any file type, up to **10 MB** per document. PlayerZero recognizes `.txt`, `.md`, `.csv`, `.json`, `.xml`, and `.yaml` with their proper content types.
 
-Documents are normalized to UTF-8 with LF line endings on upload. If you upload a file with the same name as an existing document in the group, the upload will be rejected — rename the file first.
+Uploads run directly from your browser and show a progress indicator while in flight. If you upload a file with the same name as an existing document in the group, the upload will be rejected — rename the file first.
 
 ---
 

--- a/features/monitors.mdx
+++ b/features/monitors.mdx
@@ -10,7 +10,7 @@ Monitors is currently in **beta**. Features and behavior may change as we refine
 
 ## What Are Monitors?
 
-Monitors are automated checks that run on a schedule and verify that a condition you define holds true. When a check fails, you will see it immediately, and you can configure a workflow stage to begin automatically to investigate the failure.
+Monitors are automated checks that run on a schedule and verify that a condition you define holds true. When a check fails, you will see it immediately, and you can configure a workflow to begin automatically to investigate the failure.
 
 Monitors configuration is managed at the **organization level**, but a monitor can only begin a workflow in the project you select. Navigate to **Settings → Monitors** to view and manage them.
 
@@ -28,7 +28,7 @@ Monitors configuration is managed at the **organization level**, but a monitor c
 | **What should be checked?** | The condition that should always hold true. Describe what you expect in plain language — the system evaluates this automatically. |
 | **Schedule** | How often to run the check. Use the visual schedule builder (presets for minutes, hourly, daily, weekly, monthly) or enter a cron expression manually. Minimum interval is 5 minutes. |
 | **Stop after** | *(Optional)* Automatically disable the monitor after a specific date and time. If not set, the monitor runs indefinitely. |
-| **When this fails, run** | *(Optional)* Select a project and workflow stage to trigger automatically when the check fails. |
+| **When this fails, run** | *(Optional)* Select a project and workflow to start automatically when the check fails. The workflow begins at its entry point. |
 
 4. Click **Create Monitor**
 
@@ -62,7 +62,7 @@ Creating and editing monitors requires **editor** or **owner** permissions. View
 
 The monitors page shows all monitors in your organization in a split-panel view:
 
-- **Left panel** — A paginated list of all monitors, each showing the monitor name, condition summary, schedule, workflow stage (if configured), recent result history, and last run verdict
+- **Left panel** — A paginated list of all monitors, each showing the monitor name, condition summary, schedule, workflow (if configured), recent result history, and last run verdict
 - **Right panel** — Detailed view of the selected monitor, including full condition text, schedule, expiration, result timeline, and management actions
 
 ### Filtering
@@ -79,7 +79,7 @@ Click any monitor in the list to open its detail panel. The detail view shows:
 - **What's being checked** — The full condition text
 - **Schedule** — Human-readable description of the polling schedule
 - **Stop after** — Expiration date, or "Runs indefinitely"
-- **Workflow stage** — The project and stage that triggers on failure, or "No workflow configured"
+- **Workflow** — The project and workflow that triggers on failure, or "No workflow configured"
 - **Result history** — A timeline of past evaluation results with verdict, reasoning, and workflow status
 - **Version history** — Each monitor tracks versions. Changing the monitored condition creates a new version.
 
@@ -89,11 +89,11 @@ Click any monitor in the list to open its detail panel. The detail view shows:
 
 1. Select a monitor from the list
 2. Click **Edit** in the detail panel footer
-3. Update any fields — name, condition, schedule, expiration, or workflow stage
+3. Update any fields — name, condition, schedule, expiration, or workflow
 4. Click **Save**
 
 <Note>
-Changing the monitored condition (the "What should be checked?" field) creates a new version of the monitor. Other changes (name, schedule, expiration, workflow stage) update the current version in place.
+Changing the monitored condition (the "What should be checked?" field) creates a new version of the monitor. Other changes (name, schedule, expiration, workflow) update the current version in place.
 </Note>
 
 ---
@@ -121,7 +121,7 @@ You can run a monitor immediately to verify it works without waiting for the nex
 The result appears in the result timeline once the evaluation completes. Results update in real time — you don't need to refresh the page.
 
 <Note>
-If a workflow stage is configured, a test run that fails will trigger the workflow — the same as a scheduled failure.
+If a workflow is configured, a test run that fails will trigger it — the same as a scheduled failure.
 </Note>
 
 ---
@@ -143,19 +143,19 @@ Investigation sessions show the monitor origin in the Player thread, with a link
 
 ## Workflow Integration
 
-Monitors can automatically trigger a workflow stage when a check fails. This lets you connect monitoring to your existing investigation workflows — for example, automatically starting a triage workflow when an SLA check fails.
+Monitors can automatically trigger a workflow when a check fails. This lets you connect monitoring to your existing investigation workflows — for example, automatically starting a triage workflow when an SLA check fails.
 
 To configure a workflow trigger:
 
 1. When creating or editing a monitor, use the **When this fails, run** field
 2. Select a **project** from the dropdown
-3. Select a **workflow stage** from that project
+3. Select a **workflow** from that project
 
 When the monitor fails:
 
-- **Workflow started** — A new workflow Player is created and starts processing from the configured stage
+- **Workflow started** — A new workflow Player is created and starts processing from the configured workflow's entry point
 - **Workflow skipped** — A workflow was already started in the last hour for this monitor, so the run is skipped to avoid duplicates
-- **No workflow** — No workflow stage is configured
+- **No workflow** — No workflow is configured
 - **Workflow failed** — Something went wrong when trying to start the workflow
 
 Each result in the timeline shows the workflow status so you can track what happened after each failure.
@@ -164,11 +164,11 @@ Each result in the timeline shows the workflow status so you can track what happ
 
 ## Proactive Monitors
 
-PlayerZero can automatically generate monitors when a pull request is merged. These **proactive monitors** target existing telemetry to catch regressions introduced by the merged changes.
+PlayerZero can automatically generate monitors when a pull request is merged. These **proactive monitors** target existing telemetry to catch regressions introduced by the merged changes. Proactive monitors are generated only for merges into the repository's configured release branch — merges into other branches do not trigger generation. PR-merge monitor generation is also surfaced on the PR review page — see [Automatic Monitors on Merge](/features/code-reviews#automatic-monitors-on-merge).
 
 ### How It Works
 
-When a PR is merged in a connected repository:
+When a PR is merged into a connected repository's **release branch**:
 
 1. PlayerZero analyzes the merged changes and PR context
 2. An AI agent generates up to 5 monitors targeting relevant telemetry signals

--- a/features/workflow-inbox.mdx
+++ b/features/workflow-inbox.mdx
@@ -36,11 +36,15 @@ The stage list can be collapsed to give more space to the Player list.
 
 Narrow results by time: **All Time**, **Today**, **Last 7 days**, **Last 14 days**, or **Last 30 days**.
 
+### Workflows
+
+The left panel groups Players by workflow. Choose **All Workflows** to see every Player, or a specific workflow to focus on its stages. Each workflow lists its stages beneath it, and each stage shows a count of active Players.
+
 ### Stage Selection
 
-Click any stage in the left panel to filter Players to that stage only. Click **All Stages** to see Players across every stage. Each stage shows a count of active Players.
+Click any stage to filter Players to that stage. Click **All Stages** to see Players across every stage shown.
 
-By default, stages with zero active Players are hidden from the list. Use the **Include empty stages** checkbox to show them. This preference is saved across sessions.
+By default, workflows with zero active Players are hidden. Use the **Include empty workflows** checkbox to show them. This preference is saved across sessions.
 
 ### Search
 
@@ -78,13 +82,20 @@ All without leaving the inbox.
 
 For Players in the **Needs Approval** category, you can approve the transition directly from the Player row without opening the full conversation. The row shows the current stage, the proposed target stage, and the agent's explanation for why it's ready to move on.
 
+Approval is an explicit choice, not just a yes/no on the agent's suggestion. You can:
+
+- **Approve the suggested target** as-is.
+- **Redirect to a different target** — any stage in the workflow, or another workflow's entry, that you have access to — including skipping ahead. The reviewer's choice is not limited to the step the agent suggested.
+
+The approving user is recorded with the transition. If the Player is connected to Slack or Microsoft Teams, the approval notification names who approved (and any note they added).
+
 ---
 
 ## Bulk Actions
 
 Click **Bulk Actions** to approve or archive multiple Players at once.
 
-- **Bulk Approve** — Select Players that need approval, review or change the target stage for each, and approve them all in one action
+- **Bulk Approve** — Select Players that need approval, review or change the target stage or workflow for each, and approve them all in one action
 - **Bulk Archive** — Select archivable Players and archive them together
 
 Each Player in the bulk dialog shows its current stage, the agent's suggested next stage, and any explanation or suggested approver.

--- a/features/workflows.mdx
+++ b/features/workflows.mdx
@@ -24,7 +24,7 @@ A stage is a node in the workflow graph. Each stage has a **name**, **instructio
 
 ### Transitions
 
-Transitions are the allowed paths between stages. Each transition includes a target stage and conditions describing when the agent should take that path. Transitions are validated at runtime — the agent can only move to stages explicitly defined as valid next steps.
+Transitions are the allowed paths between stages. Each transition includes a target stage and conditions describing when the agent should take that path. Transitions are validated at runtime — the agent can only move to stages explicitly defined as valid next steps. A transition can also target [another workflow's entry](/features/configuring-workflows#transition-targets), handing work off to a different workflow.
 
 ### Approvals
 
@@ -34,6 +34,8 @@ When the agent completes work in a stage, it requests to move on. Depending on c
 - **Manual approval**: A human reviews the completed work and approves the transition, optionally leaving notes for the agent
 
 Approval means accepting the work done in the current stage — confirming that the agent's output meets your expectations before it moves to the next step.
+
+Approval is a two-way decision: a reviewer can approve the agent's suggested next step, or redirect the Player to any next step they have access to — another stage, or another workflow — including skipping ahead. The approving user is recorded with the transition.
 
 ### Archival
 
@@ -57,6 +59,17 @@ Triage and RCA auto-approve so the agent moves through them autonomously. Fix, T
 
 ---
 
+## Creating a Workflow
+
+When you add a workflow to a project, you can start from any of the following:
+
+- **Start from scratch** — Build an empty workflow and add stages and transitions yourself in the [workflow builder](/features/configuring-workflows).
+- **Use a template** — Pick a pre-built workflow from the template catalog and customize it. Templates include **Engineering Scoping**, **L1 Support**, **SRE Alert Response**, **PR Review**, **QA Testing**, **Documentation**, and **Product Scoping (BMAD)**.
+- **Import from another project** — Copy a workflow from a different project in your organization into the current one.
+- **Import from JSON** — Import a workflow definition exported from another project. See [Export & Import](/features/configuring-workflows#export--import).
+
+---
+
 ## Two Surfaces
 
 ### The Workflow Builder
@@ -74,3 +87,5 @@ Manage active work across your team. Filter by stage, approval status, ownership
 - [Configuring Workflows](/features/configuring-workflows) — Set up stages, transitions, approvals, and archival
 - [Workflow Inbox](/features/workflow-inbox) — Manage active Players, approve transitions, and review work
 - [Usage Analytics](/features/additional-features/usage-analytics) — Track workflow activity and export usage data
+- [Versions & Drafts](/features/configuring-workflows#versions--drafts) — Edit workflows safely with drafts and test against draft versions
+- [API Triggers](/features/additional-features/api-triggers) — Start a workflow from an external system via an HTTP endpoint


### PR DESCRIPTION
Apply the weekly documentation refresh for product changes merged May 18 -> June 3, 2026, plus two new pages picked up as follow-up.

Weekly batch (10 existing pages):
- Workflow-centric model across API triggers, monitors, workflow inbox, and usage analytics (selection/aggregation by workflow, not stage)
- Two-way approvals in the inbox and workflows overview
- New Versions & Drafts, Transition Targets, and stage-import subsections in configuring-workflows; auto-save transitions note
- New Creating a Workflow section + cross-links in workflows
- Knowledge Bases: 10 MB upload limit, recognized formats, progress note
- Proactive/auto monitors gated to release-branch merges
- Player-launched simulations inherit repo/branch + uncommitted edits

New pages:
- features/channels.mdx (Channels & Multiplayer) + docs.json nav entry
- Branches section in features/code-reviews.mdx