### PR TITLE
Fix broken docs dashboard links

### DIFF
--- a/developer-guide/configuration-guides/capturing-user-sessions/domain-settings.mdx
+++ b/developer-guide/configuration-guides/capturing-user-sessions/domain-settings.mdx
@@ -9,7 +9,7 @@ PlayerZero allows you to control how recording and monitoring behave across diff
 
 ## Where is this?
 
-You can access these controls under [Settings > Web SDK](https://go.playerzero.app/setting/web).
+You can access these controls under [Settings > Web SDK](https://playerzero.ai/current-org/settings/projects/current-project/web-sdk).
 
 You’ll see a configuration interface that looks like this:
 

--- a/developer-guide/configuration-guides/capturing-user-sessions/npm.mdx
+++ b/developer-guide/configuration-guides/capturing-user-sessions/npm.mdx
@@ -7,7 +7,7 @@ description: "This guide walks you through setting up the PlayerZero SDK using n
 ## Prerequisites
 - Node.js and npm or yarn installed.
 - Access to your project’s frontend codebase.
-- Your PlayerZero [API Key](https://go.playerzero.app/setting/api-tokens).
+- Your PlayerZero [API Key](https://playerzero.ai/current-org/settings/projects/current-project/api-tokens).
 
 ## Step-by-Step Instructions
 
@@ -106,7 +106,7 @@ if (window.playerzero) {
 
 ## Next Steps
 
-Once the SDK is installed and initialized, you can visit the [Users page](https://go.playerzero.app/users) in PlayerZero to see live user sessions being captured.
+Once the SDK is installed and initialized, you can visit the [Users page](https://playerzero.ai/current-org/current-project/users) in PlayerZero to see live user sessions being captured.
 
 If you want to control where PlayerZero is active, visit the [Domain Settings](/developer-guide/configuration-guides/capturing-user-sessions/domain-settings) guide to configure domain-level access and environment-specific behavior.
 

--- a/developer-guide/configuration-guides/capturing-user-sessions/script-tag.mdx
+++ b/developer-guide/configuration-guides/capturing-user-sessions/script-tag.mdx
@@ -6,17 +6,17 @@ description: "This guide walks you through setting up the PlayerZero SDK using a
 
 ## Prerequisites
 - Access to your project’s frontend codebase.
-- Your PlayerZero [API Key](https://go.playerzero.app/setting/api-tokens).
+- Your PlayerZero [API Key](https://playerzero.ai/current-org/settings/projects/current-project/api-tokens).
 
 ## Step-by-Step Instructions
 
 ### 1. Add the PlayerZero Script
 
-Paste this inside your `<head>` or just before the closing `</body>` tag:
+Paste this inside your `<head>` or just before the closing `</body>` tag. Replace `YOUR_WEBSDK_TOKEN` with your API key; the placeholder URL will not load if opened directly in a browser.
 
 ```javascript
 <script type="text/javascript"
-        src="https://go.playerzero.app/record/<websdk_token>"
+        src="https://go.playerzero.app/record/YOUR_WEBSDK_TOKEN"
         async crossorigin>
 </script>
 ```
@@ -96,7 +96,7 @@ if (window.playerzero) {
 
 ## Next Steps
 
-Once the SDK is installed and initialized, you can visit the [Users page](https://go.playerzero.app/users) in PlayerZero to see live user sessions being captured.
+Once the SDK is installed and initialized, you can visit the [Users page](https://playerzero.ai/current-org/current-project/users) in PlayerZero to see live user sessions being captured.
 
 If you want to control where PlayerZero is active, visit the [Domain Settings](/developer-guide/configuration-guides/capturing-user-sessions/domain-settings) guide to configure domain-level access and environment-specific behavior.
 

--- a/developer-guide/configuration-guides/capturing-user-sessions/segment.mdx
+++ b/developer-guide/configuration-guides/capturing-user-sessions/segment.mdx
@@ -7,7 +7,7 @@ description: "This guide walks you through connecting PlayerZero to Segment to c
 
 ## Prerequisites
 - Access to Segment’s **Destination catalog**
-- Your PlayerZero [API Key](https://go.playerzero.app/setting/api-tokens).
+- Your PlayerZero [API Key](https://playerzero.ai/current-org/settings/projects/current-project/api-tokens).
 
 ## Step-by-Step Instructions
 
@@ -63,8 +63,8 @@ Once on the page:
 
 ### 2. Add Your PlayerZero Project ID
 
-- In PlayerZero, go to [Settings > Data Collection](https://go.playerzero.app/setting/data)
-- Find the **Segment** section and copy your **Project ID**
+- In PlayerZero, open your project settings and copy your **Project ID**
+- Find the **Segment** section if it appears in your workspace
 - In Segment, paste it into the `PlayerZero Project Id` field
 
 ### 3. Enable the Destination

--- a/developer-guide/configuration-guides/capturing-user-sessions/web-sdk-instrumentation.mdx
+++ b/developer-guide/configuration-guides/capturing-user-sessions/web-sdk-instrumentation.mdx
@@ -10,7 +10,7 @@ This guide walks you through installing and initializing the PlayerZero Web SDK 
 ## Basic Setup Guide
 
 ### Prerequisites
-- You’ll need your **Project ID**, which can be found under [**Settings > Web SDK**](https://go.playerzero.app/setting/web) in the PlayerZero dashboard.
+- You’ll need your **Project ID**, which can be found under [**Settings > Web SDK**](https://playerzero.ai/current-org/settings/projects/current-project/web-sdk) in the PlayerZero dashboard.
 - Decide which integration method you prefer:
   - Install the **npm** package (recommended for most modern frontend frameworks)
   - Add a direct **script** tag (no build system required)

--- a/developer-guide/configuration-guides/importing-code/azure.mdx
+++ b/developer-guide/configuration-guides/importing-code/azure.mdx
@@ -29,7 +29,7 @@ You may need to click "Show all scopes" when creating your PAT to see all availa
 ## SCM Setup Guide
 
 ### Prerequisites
-1. A PlayerZero account. You can get started by [creating an account](https://go.playerzero.app).
+1. A PlayerZero account. You can get started by [creating an account](https://playerzero.ai).
 2. Admin access to your Azure DevOps organization to:
 - Create Personal Access Tokens (PATs)
 - Configure token permissions

--- a/developer-guide/configuration-guides/importing-code/bitbucket.mdx
+++ b/developer-guide/configuration-guides/importing-code/bitbucket.mdx
@@ -23,7 +23,7 @@ Access is limited to only the repositories you explicitly select during the OAut
 
 ### Prerequisites
 
-1. A PlayerZero account. You can get started by [creating an account](https://go.playerzero.app).
+1. A PlayerZero account. You can get started by [creating an account](https://playerzero.ai).
 2. Admin access to your Bitbucket workspace to:
 
 - Authorize OAuth applications

--- a/developer-guide/configuration-guides/importing-code/github.mdx
+++ b/developer-guide/configuration-guides/importing-code/github.mdx
@@ -24,7 +24,7 @@ These permissions enable PlayerZero to provide code analysis, pull request insig
 ## Basic Setup Guide
 
 ### Prerequisites
-1. A PlayerZero account. You can get started by [creating an account](https://go.playerzero.app).
+1. A PlayerZero account. You can get started by [creating an account](https://playerzero.ai).
 2. Admin access to your GitHub organization to:
         - Install the PlayerZero GitHub App
         - Grant repository access permissions

--- a/developer-guide/configuration-guides/importing-code/gitlab.mdx
+++ b/developer-guide/configuration-guides/importing-code/gitlab.mdx
@@ -22,7 +22,7 @@ You must have at least Developer level access to the GitLab projects you want to
 ## Basic Setup Guide
 
 ### Prerequisites
-1. A PlayerZero account. You can get started by [creating an account](https://go.playerzero.app).
+1. A PlayerZero account. You can get started by [creating an account](https://playerzero.ai).
 2. Admin access to your Bitbucket workspace to:
 - Authorize OAuth applications
 - Grant repository access permissions

--- a/developer-guide/configuration-guides/importing-code/import-git-setup-guide.mdx
+++ b/developer-guide/configuration-guides/importing-code/import-git-setup-guide.mdx
@@ -23,7 +23,7 @@ If your organization uses one of these systems, you can connect it directly duri
 ## Basic Setup Guide
 
 ### Prerequisites
-1. A PlayerZero account. You can get started by [creating an account](https://go.playerzero.app).
+1. A PlayerZero account. You can get started by [creating an account](https://playerzero.ai).
 2. Admin access is required on your SCM to:
     - Grant PlayerZero read access to your code
     - Grant read/write access to manage pull requests
@@ -53,6 +53,6 @@ Want to learn different ways to talk to your codebase? Read through our guides o
 
 👉 [Ask Your Codebase Questions](/use-cases/retrieve-insights-from-code/ask-codebase-questions)
 
-👉 [Start an AI Chat session](https://go.playerzero.app)
+👉 [Start an AI Chat session](https://playerzero.ai)
 
 

--- a/developer-guide/configuration-guides/mcp-setup.mdx
+++ b/developer-guide/configuration-guides/mcp-setup.mdx
@@ -37,7 +37,7 @@ PlayerZero exposes an MCP server that any compatible AI assistant can connect to
 
 ## Step 2: Configure Your MCP Client
 
-Use Server-Sent Events (SSE) transport for most MCP clients: 
+Use Server-Sent Events (SSE) transport for most MCP clients. This endpoint is called by your MCP client with the token header; it is not a page that will load if opened directly in a browser.
 
 ```
 {

--- a/docs.json
+++ b/docs.json
@@ -210,7 +210,7 @@
     "primary": {
       "type": "button",
       "label": "Login",
-      "href": "https://go.playerzero.app"
+      "href": "https://playerzero.ai"
     }
   },
   "footer": {


### PR DESCRIPTION
Repoint dashboard navigation links away from the backend host, remove the stale Data Collection link from the Segment setup guide, and clarify endpoint examples that are not browser-loadable pages.