### PR TITLE
Update public docs for Channels and Multiworkflow release

### DIFF
--- a/connector/microsoft-teams.mdx
+++ b/connector/microsoft-teams.mdx
@@ -10,11 +10,11 @@ Microsoft Teams is a collaboration platform from Microsoft. PlayerZero's Teams i
 Once connected, you can:
 
 - **@mention or message the bot** — Mention the PlayerZero bot in any channel or send it a direct message to start a conversation. The bot responds with an interactive card to configure your investigation.
-- **Start investigations with Ask PlayerZero** — Select a project, choose a workflow or playbook, and provide your question. PlayerZero creates a Player session and responds in the thread.
-- **Approve workflow stage transitions** — When a Player needs approval to move to the next workflow stage, an interactive approval card appears in Teams with options to approve immediately or approve with a message and playbook.
-- **Receive notifications in channels** — Get workflow stage approval requests, Player summaries, and other notifications delivered to your team's channels.
-- **Open in Chat** — Link an existing PlayerZero session to a Teams channel from the PlayerZero UI, so you can continue a conversation in Teams.
-- **Reply in threads** — Continue a conversation with a Player by replying in the Teams thread. Messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+- **Start investigations with Ask PlayerZero** — Select a project, choose a workflow or playbook, and provide your question. PlayerZero creates a Player thread and responds in the Teams thread.
+- **Approve workflow stage transitions** — When a Player thread needs approval to move to the next workflow stage, an interactive approval card appears in Teams with options to approve immediately or approve with a message and playbook.
+- **Receive notifications in channels** — Get workflow stage approval requests, Player thread summaries, and other notifications delivered to your team's channels.
+- **Open in Chat** — Link an existing Player thread to a Teams channel from the PlayerZero UI, so you can continue a conversation in Teams.
+- **Reply in threads** — Continue a conversation with a Player thread by replying in the Teams thread. Messages in the Teams thread are forwarded to the Player thread, and its responses appear in the Teams thread.
 
 ## Ask PlayerZero
 
@@ -26,42 +26,42 @@ When you @mention or message the PlayerZero bot in a channel, the bot responds w
 
 The compose form includes:
 
-- **Workflow** — Optionally select a workflow to start the Player in a specific workflow stage
-- **Playbook** — Optionally select a playbook to guide the Player's approach
+- **Workflow** — Optionally select a workflow to start the Player thread in a specific workflow stage
+- **Playbook** — Optionally select a playbook to guide the Player thread's approach
 - **Message** — Describe your question or task
 
-Click **Ask** to create the Player session. PlayerZero responds in the thread with the Player's findings and a **Full Chat** link to the complete session in PlayerZero.
+Click **Ask** to create the Player thread. PlayerZero responds in the Teams thread with the Player thread's findings and a **Full Chat** link to the complete conversation in PlayerZero.
 
-If you @mention the bot in an existing thread, the initial message from that thread is automatically included as context for the Player.
+If you @mention the bot in an existing Teams thread, the initial message from that thread is automatically included as context for the Player thread.
 
 ## Workflow Stage Approvals
 
-When an AI Player needs approval to move to the next workflow stage, PlayerZero delivers an approval card to Teams. These cards appear in the thread where the Player was started (if it originated from Teams) and in any channels configured for that workflow stage.
+When a Player thread needs approval to move to the next workflow stage, PlayerZero delivers an approval card to Teams. These cards appear in the Teams thread where the Player thread was started (if it originated from Teams) and in any channels configured for that workflow stage.
 
 The approval card includes:
 
 - An **Approve** button to approve the transition immediately
 - A **Playbook** picker to optionally select a playbook before approving
 - An **Approval message** field to add context or instructions
-- A **View in PlayerZero** link to open the full Player session
+- A **View in PlayerZero** link to open the full Player thread
 
 After approval, a confirmation message is posted to the thread so the team can see who approved and any notes they included.
 
 ## Open in Chat
 
-You can link any PlayerZero session to a Teams channel directly from the PlayerZero UI.
+You can link any Player thread to a Teams channel directly from the PlayerZero UI.
 
-From a Player session in PlayerZero, click **Open in Chat** and select a Teams channel. PlayerZero creates a new thread in that channel linked to the Player — messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+From a Player thread in PlayerZero, click **Open in Chat** and select a Teams channel. PlayerZero creates a new Teams thread in that channel linked to the Player thread — messages in the Teams thread are forwarded to the Player thread, and its responses appear in the Teams thread.
 
-If the Player is already connected to a Teams thread, clicking **Open in Chat** takes you directly to that thread instead.
+If the Player thread is already connected to a Teams thread, clicking **Open in Chat** takes you directly to that Teams thread instead.
 
 ## Receive Notifications
 
 PlayerZero delivers notifications to Teams channels based on your project and workflow configuration. Notifications include:
 
-- **Workflow stage approval requests** when a Player needs human approval to continue
-- **Player response summaries** posted to threads where investigations were started
-- **Notifications from monitor-initiated Players** when a monitor triggers a new investigation and delivers results to a configured channel
+- **Workflow stage approval requests** when a Player thread needs human approval to continue
+- **Player thread response summaries** posted to Teams threads where investigations were started
+- **Notifications from monitor-initiated Player threads** when a monitor triggers a new investigation and delivers results to a configured channel
 
 Notification routing is configured per project and per workflow stage in **Settings**. See [Notification Configuration](#notification-configuration) for details.
 

--- a/connector/slack.mdx
+++ b/connector/slack.mdx
@@ -3,32 +3,32 @@ title: "Slack"
 description: "Connect Slack to PlayerZero to interact with AI Players directly from Slack — start investigations from messages, run workflows, and receive notifications in channels."
 ---
 
-Slack is a messaging platform for teams. PlayerZero's Slack integration lets you interact with AI Players directly from Slack — starting investigations from message threads, chatting with Players in DMs, and running workflows with optional playbook guidance.
+Slack is a messaging platform for teams. PlayerZero's Slack integration lets you interact with AI Players directly from Slack — starting investigations from message threads, chatting with Player threads in DMs, and running workflows with optional playbook guidance.
 
 ## What You Can Do
 
 Once connected, you can:
 
-- **Chat with Players in DMs** — Send messages directly to the PlayerZero bot to ask questions about your codebase, debug issues, or investigate problems
-- **@mention in channels** — Mention the PlayerZero bot in any channel to start a conversation. The bot creates a Player session and responds in a thread.
-- **Start investigations from messages** — Use the **Ask PlayerZero** message shortcut to send any message thread to a Player, with full thread context automatically captured and optional workflow or playbook selection
+- **Chat with Player threads in DMs** — Send messages directly to the PlayerZero bot to ask questions about your codebase, debug issues, or investigate problems
+- **@mention in channels** — Mention the PlayerZero bot in any channel to start a conversation. The bot creates a Player thread and responds in a Slack thread.
+- **Start investigations from messages** — Use the **Ask PlayerZero** message shortcut to send any message thread to a Player thread, with full thread context automatically captured and optional workflow or playbook selection
 - **Use the `/ask_playerzero` command** — Type `/ask_playerzero` in any channel to open the Ask PlayerZero modal without needing to right-click a message
 - **Open in Chat** — Link an existing PlayerZero session to a Slack channel from the PlayerZero UI, so you can continue a conversation in Slack
-- **Receive notifications in channels** — Get workflow stage approval requests, Player summaries, and other notifications delivered to your team's channels
+- **Receive notifications in channels** — Get workflow stage approval requests, Player thread summaries, and other notifications delivered to your team's channels
 
 ## Ask PlayerZero
 
 ### Message Shortcut
 
-Right-click any message (or use the ⋯ menu) and select **Ask PlayerZero** to send it to a PlayerZero AI Player.
+Right-click any message (or use the ⋯ menu) and select **Ask PlayerZero** to send it to a Player thread.
 
 1. Select **Ask PlayerZero** from the message shortcut menu
 2. Choose a **project** (if you have more than one)
-3. Optionally select a **workflow** to start the Player in a specific workflow stage, or a **playbook** to guide the Player's approach
+3. Optionally select a **workflow** to start the Player thread in a specific workflow stage, or a **playbook** to guide the Player thread's approach
 4. Add any **additional context** to supplement the thread content
 5. Click **Create**
 
-PlayerZero automatically reads the original thread and includes it as context for the AI Player. The Player session is linked back to the Slack thread — a summary of the agent's response appears in the thread with a **Full Chat** link to the complete session in PlayerZero. Messages you send in the thread are forwarded to the Player.
+PlayerZero automatically reads the original thread and includes it as context for the agent. The Player thread is linked back to the Slack message thread — a summary of the agent's response appears in the Slack thread with a **Full Chat** link to the complete conversation in PlayerZero. Messages you send in the Slack thread are forwarded to the Player thread.
 
 You can preview the instructions for a selected workflow or playbook using the **Preview** button before submitting.
 
@@ -36,11 +36,11 @@ You can preview the instructions for a selected workflow or playbook using the *
 
 Type `/ask_playerzero` in any channel to open the same Ask PlayerZero modal directly. Any text you include after the command is pre-filled into the message field.
 
-The command creates a new thread in the current channel and links it to the Player session. This is useful when you want to start an investigation without a specific message to reference.
+The command creates a new Slack thread in the current channel and links it to the Player thread. This is useful when you want to start an investigation without a specific message to reference.
 
 ### Global Shortcut
 
-Open Slack's global shortcuts menu and select **Ask PlayerZero** to start a new Player session without message context.
+Open Slack's global shortcuts menu and select **Ask PlayerZero** to start a new Player thread without message context.
 
 1. Open the global shortcuts menu
 2. Select **Ask PlayerZero**
@@ -48,39 +48,39 @@ Open Slack's global shortcuts menu and select **Ask PlayerZero** to start a new 
 4. Provide a **message** describing your question or task
 5. Click **Create**
 
-Unlike the message shortcut, this does not capture thread context — use it when you want to start a new investigation from scratch. The Player session opens in a DM with the PlayerZero bot.
+Unlike the message shortcut, this does not capture thread context — use it when you want to start a new investigation from scratch. The Player thread opens in a DM with the PlayerZero bot.
 
 ### How Thread Context Works
 
-When you trigger the message shortcut from a message that's part of a thread, PlayerZero reads the parent message of that thread and includes its content alongside your additional context. This means the AI Player understands the full conversation without you needing to copy and paste.
+When you trigger the message shortcut from a message that's part of a thread, PlayerZero reads the parent message of that thread and includes its content alongside your additional context. This means the agent understands the full conversation without you needing to copy and paste.
 
 ## Workflow Stage Approvals
 
-When an AI Player needs approval to move to the next workflow stage, PlayerZero delivers an approval notification to Slack. These notifications appear in the thread where the Player was started (if it originated from Slack) and in any channels configured for that workflow stage.
+When a Player thread needs approval to move to the next workflow stage, PlayerZero delivers an approval notification to Slack. These notifications appear in the Slack thread where the Player thread was started (if it originated from Slack) and in any channels configured for that workflow stage.
 
 The notification includes:
 
 - An **Approve** button to approve the transition immediately
 - An **Approve with message** button to add context, select a playbook, or provide instructions before approving
-- A **View in PlayerZero** link to open the full Player session
+- A **View in PlayerZero** link to open the full Player thread
 
 After approval, a confirmation message is posted to the thread so the team can see who approved and any notes they included.
 
 ## Open in Chat
 
-You can link any PlayerZero session to a Slack channel directly from the PlayerZero UI.
+You can link any Player thread to a Slack channel directly from the PlayerZero UI.
 
-From a Player session in PlayerZero, click **Open in Chat** and select a Slack channel. PlayerZero creates a new thread in that channel linked to the Player — messages in the thread are forwarded to the Player, and the Player's responses appear in the thread.
+From a Player thread in PlayerZero, click **Open in Chat** and select a Slack channel. PlayerZero creates a new Slack thread in that channel linked to the Player thread — messages in the Slack thread are forwarded to the Player thread, and its responses appear in the Slack thread.
 
-If the Player is already connected to a Slack thread, clicking **Open in Chat** takes you directly to that thread instead.
+If the Player thread is already connected to a Slack thread, clicking **Open in Chat** takes you directly to that Slack thread instead.
 
 ## Receive Notifications
 
 PlayerZero delivers notifications to Slack channels based on your project and workflow configuration. Notifications include:
 
-- **Workflow stage approval requests** when a Player needs human approval to continue
-- **Player response summaries** posted to threads where investigations were started
-- **Notifications from monitor-initiated Players** when a monitor triggers a new investigation and delivers results to a configured channel
+- **Workflow stage approval requests** when a Player thread needs human approval to continue
+- **Player thread response summaries** posted to Slack threads where investigations were started
+- **Notifications from monitor-initiated Player threads** when a monitor triggers a new investigation and delivers results to a configured channel
 
 Notification routing is configured per project and per workflow stage in **Settings**. See [Notification Configuration](#notification-configuration) for details.
 

--- a/developer-guide/configuration-guides/mcp-setup.mdx
+++ b/developer-guide/configuration-guides/mcp-setup.mdx
@@ -10,7 +10,7 @@ PlayerZero exposes an MCP server that any compatible AI assistant can connect to
 
 - Active PlayerZero account with project access  
 - *Editor* or *Owner* permissions in that project  
-- An MCP-compatible AI assistant (VS Code, Copilot, Cursor, etc.)
+- An MCP-compatible AI assistant (VS Code, Copilot, Cursor, Claude Code, etc.)
 
 ---
 
@@ -37,7 +37,7 @@ PlayerZero exposes an MCP server that any compatible AI assistant can connect to
 
 ## Step 2: Configure Your MCP Client
 
-Use Server-Sent Events (SSE) transport for most MCP clients. This endpoint is called by your MCP client with the token header; it is not a page that will load if opened directly in a browser.
+The PlayerZero MCP endpoint speaks the standard **Streamable HTTP** transport with server-sent events (SSE), so mainstream MCP clients such as Claude Code and Cursor connect directly. Point your client at the endpoint and pass your token in the `Authorization` header, as shown below. This endpoint is called by your MCP client with the token header; it is not a page that will load if opened directly in a browser.
 
 ```
 {

--- a/features/ai-player.mdx
+++ b/features/ai-player.mdx
@@ -8,7 +8,43 @@ description: "PlayerZero's AI Player serves as your knowledge partner, helping y
 
 PlayerZero's **AI Players** acts as your **knowledge-rich agents**, designed to help you understand, investigate, and solve problems across your codebase and systems. Whether you're debugging a tricky issue, exploring architecture, or researching historical changes, the AI Player provides fast, context-aware insights.
 
+Each AI Player conversation runs as a **thread** inside a **channel** — a shared workspace built around a single objective. A channel can hold several threads working in parallel, so an investigation that starts as one question can grow into a coordinated effort without losing context.
+
 To use it, navigate to any project in PlayerZero and start a conversation through the free‑form prompt interface.
+
+---
+
+## Channels and Threads
+
+A PlayerZero **channel** is a shared workspace built around a single objective, such as debugging a single support ticket or scoping a change to a specific product feature. Inside a channel, work happens in **threads** — each thread is its own AI Player conversation with a focus on a single topic, such as understanding steps to reproduce or debating the pros and cons of a technical approach, but threads within a channel all share context with each other to ensure collaborative work happens without context getting lost along the way.
+
+- **Channel** — the shared workspace and objective that threads collaborate within. Context, branches, and referenced files are shared across the channel.
+- **Thread** — an individual agent conversation. A thread can run in Agent Mode or Hive Mode and keeps its own history, context, and sandbox.
+- **Coordinator** — keeps threads aligned with the channel's objective, relays context between them, and tracks overall progress.
+
+The side panel lists every thread in the channel, **grouped by workflow**, so you can see all the work in progress at a glance. Teammate threads created in [Hive Mode](/features/hive-mode) appear here as first-class entries alongside the threads you start yourself.
+
+---
+
+## Working Across Threads
+
+Threads in a channel are not isolated. When you start a new thread, it inherits context from the channel so it can pick up where other threads left off.
+
+- **Inherited context** — A new thread carries the channel's objective and plan, a record of the threads that came before it, and the files those threads referenced.
+- **Inherited branches** — Starting a new thread from an existing one (using ⌘K or **New Thread**) carries over the repositories and branches the source thread was working on.
+- **Thread-to-thread messaging** — Threads can send context and findings to one another, and the coordinator relays updates so work flows across the channel.
+
+A handoff from one thread to another keeps the history it depends on, whether the work moves from investigation to fix or from one team to another.
+
+---
+
+## Add Your Attachments to a Thread
+
+You can attach files directly in the prompt window — images, screenshots, PDFs, spreadsheets, source code, and more. Each file uploads to the thread immediately and becomes part of the channel's shared sandbox, so the agent can read and work from it.
+
+PlayerZero supports a broad range of types, including plain text and markdown, data and configuration files, source code, PDF, Microsoft Office, and OpenDocument formats. You can attach up to 10 files per message, and a large block of pasted text converts into a file automatically.
+
+Bring your own design specs, logs, spreadsheets, and code into a thread instead of pasting fragments into the conversation. The agent works from the actual documents your team already maintains, and references them as file citations in its responses.
 
 ---
 
@@ -97,6 +133,16 @@ Ask about **functionality in plain English** and the AI will:
   - Search your entire repository with **semantic understanding** (not just keywords).  
   - **Map relationships** across files.  
   - Suggest **related areas of code** you may not have considered.  
+</Accordion>
+
+<Accordion title="File Citations">
+- The agent links to the specific **files and lines** it read or changed, across your repositories and the thread's sandbox.
+- Click a citation to open the referenced file, so you can verify findings against the actual source.
+</Accordion>
+
+<Accordion title="Work Activity Grouping">
+- Related steps the agent takes — searches, file reads, edits, and tool calls — are **grouped together** in the conversation.
+- This keeps long investigations readable, so you can follow what the agent did without scrolling through every individual action.
 </Accordion>
 
 </AccordionGroup>

--- a/features/configuring-workflows.mdx
+++ b/features/configuring-workflows.mdx
@@ -17,7 +17,7 @@ Each stage defines what the agent does during that phase of work.
 | **Type** | **Entry** (starting point), **Work** (intermediate), or **Terminal** (end point). |
 | **Auto-approve** | If enabled, transitions out of this stage happen without human approval. |
 | **Approver config** | Who can approve: **Player** (agent suggests based on code ownership) or **Individuals** (specific team members). |
-| **Archive config** | How completed Players are archived: **Never**, **Manual**, or **Automatic** (after N days). |
+| **Archive config** | How completed threads are archived: **Never**, **Manual**, or **Automatic** (after N days). |
 | **Ask a human** | Optional guidance on when the agent should stop and escalate to a person. |
 
 ### Stage Types
@@ -85,17 +85,33 @@ When a human reviews a transition request, they are approving the work completed
 
 | Mode | Behavior |
 |---|---|
-| **Never** | Player is never auto-archived from this stage |
-| **Manual** | Users can archive Players manually from the Player title bar or the inbox |
-| **Automatic** | Players are archived after a configurable number of days (1, 7, 14, or 30) |
+| **Never** | Thread is never auto-archived from this stage |
+| **Manual** | Users can archive threads manually from the thread title bar or the inbox |
+| **Automatic** | Threads are archived after a configurable number of days (1, 7, 14, or 30) |
 
-Archiving marks a Player with an archived flag — it does not move the Player to a different stage. Archived Players can be viewed using the **Archived** filter in the inbox, with sub-filters for **Manually Archived** and **Automatically Archived**. Archived Players can be restored at any time.
+Archiving marks a thread with an archived flag — it does not move the thread to a different stage. Archived threads can be viewed using the **Archived** filter in the inbox, with sub-filters for **Manually Archived** and **Automatically Archived**. Archived threads can be restored at any time.
 
 ---
 
+## Workflow Versioning
+
+Workflows use a draft and publish lifecycle:
+
+- **Draft** — Edit stages, transitions, and rules without affecting running work. Changes are saved to the draft.
+- **Publish** — When the draft is ready, publish it to make it the active version. New work uses the published version.
+- **Version history** — PlayerZero keeps every published version. Review past versions and **roll back** to a previous one when needed.
+
+The inbox, monitors, and ticketing resolve against the published version of each workflow.
+
+## Starting from a Template
+
+PlayerZero ships with built-in workflow templates you can use as starting points: Documentation, Engineering Scoping, L1 Support, PR Review, Product Scoping, QA Testing, and SRE Alert Response. Create a new workflow from a template, then adjust the stages to fit how your team works.
+
+You can also create a workflow by **importing** one — from a JSON export or from another project's published workflow.
+
 ## The Workflow Builder
 
-The visual editor for designing workflows. Access it from **Settings > Stages** in your project.
+The visual editor for designing workflows. Access it from **Project Settings → Workflows** in your project, then open a workflow to edit its stages and transitions on the canvas.
 
 ### Canvas
 
@@ -122,13 +138,15 @@ The builder displays warning indicators on stages that are missing:
 
 ### Deleting a Stage
 
-When you delete a stage that has active Players, you'll be prompted to choose a destination stage. All Players currently in the deleted stage are moved to the destination, and any pending transition requests targeting the deleted stage are automatically redirected.
+When you delete a stage that has active threads, you'll be prompted to choose a destination stage. All threads currently in the deleted stage are moved to the destination, and any pending transition requests targeting the deleted stage are automatically redirected.
 
-If some Players fail to transition (for example, due to a network issue or a stuck session), the dialog shows which Players failed and why. You can retry the operation, or click **Delete Anyway** to remove the stage regardless — Players that couldn't be moved will remain in their current state and can be reassigned manually.
+If some threads fail to transition (for example, due to a network issue or a stuck session), the dialog shows which threads failed and why. You can retry the operation, or click **Delete Anyway** to remove the stage regardless — threads that couldn't be moved will remain in their current state and can be reassigned manually.
 
 ### Export & Import
 
 Export your workflow as JSON (stages, transitions, agent rules, layout positions). Import into other projects to replicate workflows across your organization.
+
+You can also import directly from another project's published workflow, so a process proven in one project can be reused in another without exporting a file first.
 
 When importing into a project that already has stages, the import dialog detects conflicting stage names and lets you resolve each one individually:
 
@@ -143,7 +161,7 @@ Stages that don't conflict with existing names are imported automatically withou
 
 ## The Workflow Inbox
 
-The inbox is the operational view for managing active Players across your workflow. For full documentation, see [Workflow Inbox](/features/workflow-inbox).
+The inbox is the operational view for managing active threads across your workflow. For full documentation, see [Workflow Inbox](/features/workflow-inbox).
 
 ---
 

--- a/features/hive-mode.mdx
+++ b/features/hive-mode.mdx
@@ -27,7 +27,7 @@ This is the right choice when accuracy matters more than speed: complex debuggin
 
 Toggle between Agent and Hive using the **mode slider** next to the chat input.
 
-- The slider appears on the **homepage** when creating a new Player and in the **chat input** of an existing Player
+- The slider appears on the **homepage** when creating a new thread and in the **chat input** of an existing thread
 - Your preference is remembered across sessions
 - Workflow stages can set a **preferred mode** — when you enter a stage, the mode adjusts automatically
 
@@ -114,6 +114,8 @@ While agents are working, the **Hive tab** in the side panel shows real-time sta
 - **Live breadcrumbs** show what each agent is currently doing (e.g., "Reading auth-service/login.ts", "Searching for rate limit errors")
 - Animated indicators show when agents are **communicating with each other** — exchanging findings, asking follow-up questions, or sharing context
 - Click any agent to see its objective and dependencies
+
+Each specialist agent runs as its own **thread** in the channel. Beyond the Hive tab, these teammate threads appear in the channel's thread roster grouped by workflow, so you can open any one of them directly and follow its full history. The **coordinator** keeps the team aligned with the channel objective and relays context between threads as the work proceeds.
 
 In the chat stream, you'll see:
 

--- a/features/workflow-inbox.mdx
+++ b/features/workflow-inbox.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Workflow Inbox"
 sidebarTitle: "Inbox"
-description: "Manage active work across your team — filter by stage, approve transitions, archive completed Players, and review work inline."
+description: "Manage active work across your team — filter by stage, approve transitions, archive completed threads, and review work inline."
 ---
 
 ## What Is the Inbox?
 
-The Workflow Inbox is the operational hub for managing active Players across your workflow. It gives you a real-time view of all work in progress, organized by stage and status. Access it from **Inbox** in your project navigation.
+The Workflow Inbox is the operational hub for managing active threads across your workflow channels. It gives you a real-time view of all work in progress, organized by stage and status. Access it from **Inbox** in your project navigation.
 
 ---
 
@@ -14,23 +14,27 @@ The Workflow Inbox is the operational hub for managing active Players across you
 
 The inbox uses a two-panel layout:
 
-- **Left panel** — Stage list, filters, and Player list grouped by status
-- **Right panel** — Full Player conversation and context for the selected Player
+- **Left panel** — Stage list, filters, and thread list grouped by status
+- **Right panel** — Full thread conversation and context for the selected thread
 
-The stage list can be collapsed to give more space to the Player list.
+The stage list can be collapsed to give more space to the thread list.
 
 ---
 
 ## Filtering
 
+### Workflow
+
+When a project has more than one workflow, the inbox is scoped to a single workflow at a time. Select the workflow you want to review; the stage list, counts, and all other filters apply within that workflow.
+
 ### View Filters
 
 | Filter | Shows |
 |---|---|
-| **Active** | All non-archived Players |
-| **My Issues** | Players where you contributed or need to approve |
-| **Engineering** | Players in engineering-focused stages |
-| **Archived** | Completed or archived Players (with sub-filters for Manually Archived vs. Automatically Archived) |
+| **Active** | All non-archived threads |
+| **My Issues** | Threads where you contributed or need to approve |
+| **Engineering** | Threads in engineering-focused stages |
+| **Archived** | Completed or archived threads (with sub-filters for Manually Archived vs. Automatically Archived) |
 
 ### Time Range
 
@@ -38,24 +42,24 @@ Narrow results by time: **All Time**, **Today**, **Last 7 days**, **Last 14 days
 
 ### Stage Selection
 
-Click any stage in the left panel to filter Players to that stage only. Click **All Stages** to see Players across every stage. Each stage shows a count of active Players.
+Click any stage in the left panel to filter threads to that stage only. Click **All Stages** to see threads across every stage. Each stage shows a count of active threads.
 
-By default, stages with zero active Players are hidden from the list. Use the **Include empty stages** checkbox to show them. This preference is saved across sessions.
+By default, stages with zero active threads are hidden from the list. Use the **Include empty stages** checkbox to show them. This preference is saved across sessions.
 
 ### Search
 
-Use the search bar at the top of the Player list to find Players by name or ticket key across all stages. If a Player was created from a ticket (e.g., a Jira or Linear issue), you can search by the ticket identifier (e.g., "PROJ-456") in addition to the Player's title.
+Use the search bar at the top of the thread list to find threads by name or ticket key across all stages. If a thread was created from a ticket (e.g., a Jira or Linear issue), you can search by the ticket identifier (e.g., "PROJ-456") in addition to the thread's title.
 
 ---
 
-## Player Categories
+## Thread Categories
 
-Within the selected stage(s), Players are grouped by status:
+Within the selected stage(s), threads are grouped by status:
 
 - **Needs Approval** — The agent has completed work and is requesting to transition. Shows the current stage, target stage, the agent's explanation, and a suggested approver. An **Approve** button is available inline.
 - **Needs Input** — The agent is waiting for information or human guidance before continuing.
 - **In Progress** — The agent is actively working. A live breadcrumb shows what it's currently doing.
-- **Done** — Stage work is complete. Shows when the Player finished.
+- **Done** — Stage work is complete. Shows when the thread finished.
 
 Each section can be expanded or collapsed independently.
 
@@ -65,7 +69,7 @@ Each section can be expanded or collapsed independently.
 
 ### Inline Review
 
-Click any Player to open its full conversation in the right panel. You can:
+Click any thread to open its full conversation in the right panel. You can:
 
 - Read the full conversation history and agent reasoning
 - Approve transitions to the next stage
@@ -76,33 +80,33 @@ All without leaving the inbox.
 
 ### Inline Approval
 
-For Players in the **Needs Approval** category, you can approve the transition directly from the Player row without opening the full conversation. The row shows the current stage, the proposed target stage, and the agent's explanation for why it's ready to move on.
+For threads in the **Needs Approval** category, you can approve the transition directly from the thread row without opening the full conversation. The row shows the current stage, the proposed target stage, and the agent's explanation for why it's ready to move on.
 
 ---
 
 ## Bulk Actions
 
-Click **Bulk Actions** to approve or archive multiple Players at once.
+Click **Bulk Actions** to approve or archive multiple threads at once.
 
-- **Bulk Approve** — Select Players that need approval, review or change the target stage for each, and approve them all in one action
-- **Bulk Archive** — Select archivable Players and archive them together
+- **Bulk Approve** — Select threads that need approval, review or change the target stage for each, and approve them all in one action
+- **Bulk Archive** — Select archivable threads and archive them together
 
-Each Player in the bulk dialog shows its current stage, the agent's suggested next stage, and any explanation or suggested approver.
+Each thread in the bulk dialog shows its current stage, the agent's suggested next stage, and any explanation or suggested approver.
 
 ---
 
 ## Sort Order
 
-Toggle between **newest first** and **oldest first** to control how Players are ordered within each category.
+Toggle between **newest first** and **oldest first** to control how threads are ordered within each category.
 
 ---
 
 ## Keyboard Navigation
 
-Navigate the Player list using the keyboard:
+Navigate the thread list using the keyboard:
 
-- **↑ / ↓** — Move between Players
-- **Enter** — Open the focused Player in the review panel
+- **↑ / ↓** — Move between threads
+- **Enter** — Open the focused thread in the review panel
 
 ---
 

--- a/features/workflows.mdx
+++ b/features/workflows.mdx
@@ -6,9 +6,17 @@ description: "Define multi-stage pipelines that govern how PlayerZero agents pro
 
 ## What Is a Workflow?
 
-A Workflow is a customizable, multi-stage pipeline that controls how a PlayerZero agent (a **Player**) processes work from start to finish. You define the stages, the allowed paths between them, and the rules that control progression.
+A Workflow is a customizable, multi-stage pipeline that controls how a PlayerZero agent processes work from start to finish. You define the stages, the allowed paths between them, and the rules that control progression.
 
-When a Player enters a workflow, it moves through stages like **Intake & Triage → RCA → Fix → Test → Document & Close**. At each stage, the agent receives specific instructions, performs its work, and then requests permission to advance. Transitions can be auto-approved or gated behind human review.
+When a channel enters a workflow, it moves through stages like **Intake & Triage → RCA → Fix → Test → Document & Close**. Each stage will operate across one or more agent threads. Each thread receives workflow-specific instructions, performs its work, and then requests permission to advance. Transitions can be auto-approved or gated behind human review.
+
+---
+
+## Multiple Workflows per Project
+
+A project can define **multiple workflows**, each modeling a distinct process — for example, support triage, engineering scoping, QA testing, or SRE response. Manage them from **Project Settings → Workflows**.
+
+Each workflow is **versioned**. You edit a draft, publish it when ready, and PlayerZero keeps the full version history so you can **roll back** to a previous published version at any time. The inbox, monitors, and ticketing all resolve against the published version of a workflow.
 
 ---
 
@@ -37,7 +45,7 @@ Approval means accepting the work done in the current stage — confirming that 
 
 ### Archival
 
-Completed Players can be archived manually or automatically after a configurable number of days. Archived Players can be restored at any time.
+Completed threads can be archived manually or automatically after a configurable number of days. Archived threads can be restored at any time.
 
 ---
 
@@ -55,6 +63,8 @@ Every project starts with a five-stage defect resolution workflow:
 
 Triage and RCA auto-approve so the agent moves through them autonomously. Fix, Test, and Close require human approval — putting humans in the loop where high-stakes decisions happen.
 
+Beyond the default, you can start a new workflow from a built-in template or build your own. See [Configuring Workflows](/features/configuring-workflows).
+
 ---
 
 ## Two Surfaces
@@ -65,12 +75,12 @@ Design workflows using a visual drag-and-drop graph editor. Add stages, draw con
 
 ### The Workflow Inbox
 
-Manage active work across your team. Filter by stage, approval status, ownership, and time range. Review Players inline and approve transitions without leaving the inbox. [Learn more →](/features/workflow-inbox)
+Manage active work across your team. Filter by workflow, stage, approval status, ownership, and time range. Review threads inline and approve transitions without leaving the inbox. [Learn more →](/features/workflow-inbox)
 
 ---
 
 ## Get Started
 
 - [Configuring Workflows](/features/configuring-workflows) — Set up stages, transitions, approvals, and archival
-- [Workflow Inbox](/features/workflow-inbox) — Manage active Players, approve transitions, and review work
+- [Workflow Inbox](/features/workflow-inbox) — Manage active threads, approve transitions, and review work
 - [Usage Analytics](/features/additional-features/usage-analytics) — Track workflow activity and export usage data

--- a/how-playerzero-works.mdx
+++ b/how-playerzero-works.mdx
@@ -11,6 +11,24 @@ This guide starts by covering PlayerZero’s architecture, then dives into how e
 
 ---
 
+## Channels, Threads, and Workflows
+
+PlayerZero organizes work into channels and threads, with workflows defining the process each thread follows.
+
+- **Channel** — a shared workspace built around a single objective. Threads collaborate inside a channel and share its context, branches, and referenced files.
+- **Thread** — an individual agent conversation, with its own context and sandbox. A thread is what older material may call a "Player."
+- **Coordinator** — keeps the threads in a channel aligned with the objective, relays context between them, and tracks overall progress.
+- **Workflow** — a multi-stage process a thread moves through, such as triage, investigation, fix, and review. A project can run several workflows. See [Workflows](/features/workflows).
+
+Two capabilities make this work as a team:
+
+- **Multiplayer** is coordination **within** a team on a single initiative — multiple threads collaborating in one channel so several investigations run at once without losing the thread.
+- **Multiworkflow** is coordination **across** teams, even in the same channel — support, product, engineering, and QA can hand work off without losing the intent of the change or what was deliberately added to or removed from scope.
+
+Together they close the context gap that slows handoffs between teams.
+
+---
+
 ## Code as a Foundation
 
 PlayerZero starts with a guiding principle: **every technical defect, performance bottleneck, or user issue ties back to your codebase.** By grounding all insights in the code itself, we ensure that data from observability, customer support, and other platforms augments—rather than distracts from—the lines of code that drive your product.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,6 +6,7 @@ mode: "wide"
 
 import { HowPlayerZeroWorks, DeployPlayerZero, DefectResolution } from '/snippets/landing-card.mdx';
 
+PlayerZero opens into a channel: a shared workspace where threads work together toward a single objective, coordinated as a team. Start here to learn how the pieces fit.
 
 <CardGroup cols={2}>
  <HowPlayerZeroWorks


### PR DESCRIPTION
Reframe the AI Player overview around channels and threads and add Channels and Threads, Working Across Threads, and attachment sections, plus File Citations and Work Activity Grouping. Document multiple workflows per project, workflow versioning, built-in templates, and cross-project import, and add a workflow filter to the inbox. Note the standard Streamable HTTP transport for the MCP server. Add a channels, threads, and workflows mental model to how-playerzero-works and a framing line to the landing page.

Migrate "Player" terminology to "thread" across these pages where it refers to an individual agent conversation, preserving the AI Players product name. On the Slack and Teams pages, use "Player thread" versus "Slack thread"/"Teams thread" to disambiguate the two.