### PR TITLE
Migrate Player terminology across remaining docs pages

### DIFF
--- a/connector/azure-devops.mdx
+++ b/connector/azure-devops.mdx
@@ -66,7 +66,7 @@ You can change this selection at any time after setup from the integration detai
 
 Once connected, you can configure automated workflows for each enabled project:
 
-- **Ticket routing** — Automatically create work items from Player sessions
+- **Ticket routing** — Automatically create work items from Player threads
 - **Filters** — Specify which issues should trigger the integration based on title, description, or tags
 
 ### Managing the Integration

--- a/connector/datadog.mdx
+++ b/connector/datadog.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Datadog"
-description: "Connect the Datadog MCP server to PlayerZero so AI agents can query monitors, dashboards, logs, and more directly from Player sessions."
+description: "Connect the Datadog MCP server to PlayerZero so AI agents can query monitors, dashboards, logs, and more directly from Player threads."
 ---
 
 Datadog is a monitoring and observability platform. PlayerZero connects to Datadog's remote MCP server, giving AI agents direct access to your Datadog data during investigations.
@@ -60,7 +60,7 @@ This connection uses PlayerZero's Remote MCP Servers feature. Datadog authentica
    - **Key:** `DD-APPLICATION-KEY` → **Value:** your Datadog Application key
 7. Click **Add**
 
-PlayerZero validates the connection by reaching out to the Datadog MCP server. If the connection is successful, tools from Datadog are automatically available in Player sessions for the selected projects.
+PlayerZero validates the connection by reaching out to the Datadog MCP server. If the connection is successful, tools from Datadog are automatically available in Player threads for the selected projects.
 
 If the connection fails, PlayerZero will display an error message. Common issues include:
 
@@ -68,11 +68,11 @@ If the connection fails, PlayerZero will display an error message. Common issues
 - **Connection timed out** — Verify the MCP Server URL is correct and the server is reachable
 - **Could not resolve host** — Verify the MCP Server URL is correct
 
-## Using Datadog in Player Sessions
+## Using Datadog in PlayerZero
 
-After setup, AI agents in Player sessions can access Datadog data alongside your codebase. You don't need to do anything special — agents automatically use Datadog tools when relevant to the investigation.
+After setup, AI agents in Player threads can access Datadog data alongside your codebase. You don't need to do anything special — agents automatically use Datadog tools when relevant to the investigation.
 
-For example, you can ask a Player:
+For example, you can ask a Player thread:
 
 ```
 Check if there are any triggered monitors related to the payment service.

--- a/connector/jira.mdx
+++ b/connector/jira.mdx
@@ -55,7 +55,7 @@ Setup starts in PlayerZero—no pre-configuration in Jira is required.
 3. You'll be redirected to Jira to log in and authorize PlayerZero
 4. After authorization, select which PlayerZero projects should have access to this integration
 
-## Using Jira from a Player Session
+## Using Jira from PlayerZero
 
 Once Jira is connected via **Settings → Context → Ticketing** and enabled for your project, AI Players can interact with Jira during any conversation or workflow stage. The Jira tools are automatically available — no additional configuration is needed.
 
@@ -74,7 +74,7 @@ You can also instruct agents to create Jira tickets as part of a workflow stage.
 
 ### Adding Comments to Existing Tickets
 
-If a Player session was triggered from an existing Jira ticket (or you reference one during the conversation), the agent can add comments with investigation findings, root cause analysis, or code references directly to the ticket.
+If a Channel was triggered from an existing Jira ticket (or you reference one during the conversation), the agent can add comments with investigation findings, root cause analysis, or code references directly to the ticket.
 
 ### Comment Visibility
 

--- a/connector/remote-mcp-servers.mdx
+++ b/connector/remote-mcp-servers.mdx
@@ -74,7 +74,7 @@ For Datadog, select **No authentication** and add two custom headers: `DD-API-KE
 
 6. Click **Add**
 
-PlayerZero validates the connection by reaching out to the MCP server. If successful, tools from the server are automatically available in Player sessions for the selected projects.
+PlayerZero validates the connection by reaching out to the MCP server. If successful, tools from the server are automatically available in Channels for the selected projects.
 
 If the connection fails, you'll see an error message. Common issues:
 
@@ -116,7 +116,7 @@ By default, all tools discovered from an MCP server are enabled. Editors and own
 Each tool shows its name and description. Tools that can modify data on the remote server are marked with a **WRITE** badge. Disabled tools display a **DISABLED** badge.
 
 <Note>
-Tool changes apply to newly-created Player sessions only. Existing sessions continue to use the tool set that was active when they were created.
+Tool changes apply to newly-created Channels only. Existing sessions continue to use the tool set that was active when they were created.
 </Note>
 
 Viewers can see the list of enabled and disabled tools but cannot make changes.

--- a/developer-guide/configuration-guides/extensions/chrome.mdx
+++ b/developer-guide/configuration-guides/extensions/chrome.mdx
@@ -61,7 +61,7 @@ description: "Bring PlayerZero's AI Player directly into your browser. Capture a
 4. **Verify connection**
    - Navigate to any webpage
    - The **floating toolbar** should appear near the bottom of the page when the side panel is open
-   - The extension badge may show a number if you have active Players needing input
+   - The extension badge may show a number if you have active Threads needing input
 
 ---
 
@@ -73,9 +73,9 @@ Try a quick test to confirm everything is connected:
 2. Open the side panel (click the PlayerZero icon)
 3. Click the **full page capture** button on the floating toolbar (page icon with a plus)
 4. Type a question like "What does this page do?" in the side panel
-5. Click **Submit** — a new AI Player session will be created
+5. Click **Submit** — a new Channel will be created
 
-If the Player starts successfully, you're all set.
+If the Channel starts successfully, you're all set.
 
 ---
 
@@ -93,7 +93,7 @@ If the Player starts successfully, you're all set.
 <Accordion title="Usage Tips">
 - **Capture before asking:** Attach page context to give the AI Player more to work with
 - **Use partial capture** to focus on a specific error message, component, or section rather than the full page
-- **Check the badge** — the orange badge count tells you how many Players need your input
+- **Check the badge** — the orange badge count tells you how many Threads need your input
 </Accordion>
 
 <Accordion title="Browser Permissions">

--- a/features/additional-features/api-triggers.mdx
+++ b/features/additional-features/api-triggers.mdx
@@ -6,7 +6,7 @@ description: "Allow external systems to start PlayerZero workflows by calling an
 
 ## What Are API Triggers?
 
-API Triggers let external systems — such as CI/CD pipelines, monitoring tools, or internal scripts — start PlayerZero workflows by sending an HTTP POST request to a unique endpoint. Each trigger is mapped to a specific workflow stage, so when the endpoint is called, a new Player session is created and begins processing from that stage.
+API Triggers let external systems — such as CI/CD pipelines, monitoring tools, or internal scripts — start PlayerZero workflows by sending an HTTP POST request to a unique endpoint. Each trigger is mapped to a specific workflow stage, so when the endpoint is called, a new Channel is created and begins processing from that stage.
 
 Trigger configuration is managed at the **organization level**. Navigate to **Settings → API Triggers** to view and manage them.
 
@@ -47,7 +47,7 @@ curl -X POST https://sdk.playerzero.app/workflow/start/YOUR_TRIGGER_TOKEN \
   -d '{"message": "Deploy completed for service checkout-api, build #1042"}'
 ```
 
-The request body is passed as context to the workflow Player session. You can include any JSON payload — incident details, deployment metadata, alert information, or any other context that helps the workflow investigate or act.
+The request body is passed as context to the workflow Channel. You can include any JSON payload — incident details, deployment metadata, alert information, or any other context that helps the workflow investigate or act.
 
 ### Response
 
@@ -164,10 +164,10 @@ When a trigger endpoint is called:
 1. **Authentication** — The trigger token is validated and the trigger must be active
 2. **Security checks** — CIDR and HMAC validation are applied (if configured)
 3. **Payload storage** — The request body is stored securely
-4. **Workflow creation** — A new Player session is created and starts processing from the configured workflow stage, with the request body as context
-5. **Cleanup** — The stored payload is deleted after the Player session is created
+4. **Workflow creation** — A new Channel is created and starts processing from the configured workflow stage, with the request body as context
+5. **Cleanup** — The stored payload is deleted after the Channel is created
 
-Players created by API Triggers are labeled with an **API Trigger** origin in the workflow inbox, making them easy to identify and track.
+Channels created by API Triggers are labeled with an **API Trigger** origin in the workflow inbox, making them easy to identify and track.
 
 ---
 

--- a/features/additional-features/chrome-extension.mdx
+++ b/features/additional-features/chrome-extension.mdx
@@ -49,13 +49,13 @@ The extension includes a **floating toolbar** that appears on any webpage when t
 
 ## Asking the AI Player
 
-Once you've optionally captured page context, you can start an AI Player session directly from the side panel.
+Once you've optionally captured page context, you can start a Channel directly from the side panel.
 
 <AccordionGroup>
 
 <Accordion title="Ask Mode">
 - **What it does:** Submit a free-form question to the AI Player, optionally with page context attached.
-- **How to use:** Type your question in the text box and press **Submit**. The AI creates a new Player session using your question and any attached page context.
+- **How to use:** Type your question in the text box and press **Submit**. The AI creates a new channel using your question and any attached page context.
 - **Best for:** Quick investigations, understanding what a page does, or asking why a specific error is showing.
 </Accordion>
 
@@ -84,30 +84,30 @@ Once you've optionally captured page context, you can start an AI Player session
 
 ## Managing Your Backlog
 
-The side panel includes a **backlog view** so you can track all your active AI Player sessions without leaving the browser.
+The side panel includes a **backlog view** so you can track all your active PlayerZero threads without leaving the browser.
 
 <img
   src="/images/features/chrome-extension/chrome-extension-backlog.png"
-  alt="Chrome Extension backlog view showing Workflow and Asked tabs with Player session list"
+  alt="Chrome Extension backlog view showing Workflow and Asked tabs with thread list"
 />
 
 <AccordionGroup>
 
 <Accordion title="Asked Tab">
-- Shows your most recent **Ask mode** Player sessions.
-- Click any item to open the full Player conversation in the PlayerZero web app.
+- Shows your most recent **Ask mode** Player threads.
+- Click any item to open the full Player thread in the PlayerZero web app.
 </Accordion>
 
 <Accordion title="Workflow Tab">
-- Shows **Workflow Players** grouped into three categories:
-  - **Needs Input** — Players waiting for your response or action
-  - **In Progress** — Players currently running
-  - **Done** — Completed Players
-- Use the **"Started on this page"** filter to see only Players you launched from the current webpage.
+- Shows **Workflow Threads** grouped into three categories:
+  - **Needs Input** — Threads waiting for your response or action
+  - **In Progress** — Threads currently running
+  - **Done** — Completed Threads
+- Use the **"Started on this page"** filter to see only Threads you launched from the current webpage.
 </Accordion>
 
 <Accordion title="Badge Notifications">
-- The extension icon shows an **orange badge** with the number of Players that need your input.
+- The extension icon shows an **orange badge** with the number of Threads that need your input.
 - The badge updates automatically every 30 seconds so you always know when something needs attention.
 - Open the side panel and check the **Needs Input** section to see what's waiting for you.
 </Accordion>

--- a/features/code-sim.mdx
+++ b/features/code-sim.mdx
@@ -121,7 +121,7 @@ Run scenarios through AI-powered simulation — no actual code execution require
 <AccordionGroup>
 
 <Accordion title="Inline Editing">
-- Edit scenarios directly from the Player side panel or the branch review page
+- Edit scenarios directly from the side panel or the branch review page
 - Use the keyboard-driven step editor: **Enter** to add a new step, **Backspace** on an empty step to delete it
 - Quick-add scenarios to playlists without leaving the current view
 </Accordion>

--- a/features/knowledge-bases.mdx
+++ b/features/knowledge-bases.mdx
@@ -6,7 +6,7 @@ description: "Upload organizational documents so AI agents can search and refere
 
 ## What Are Knowledge Bases?
 
-Knowledge Bases let you upload organizational documents — runbooks, API docs, style guides, internal references — and make them available to AI agents during Player sessions. When a knowledge base exists, agents automatically get access to a specialist teammate that can search and read your documents.
+Knowledge Bases let you upload organizational documents — runbooks, API docs, style guides, internal references — and make them available to Channels and Threads. When a knowledge base exists, agents automatically get access to a specialist teammate that can search and read your documents.
 
 Access Knowledge Bases from **Settings → Context → Knowledge Bases** in the sidebar.
 
@@ -63,7 +63,7 @@ To delete an entire group, use the **Delete Group** button on the group detail p
 
 ## How Agents Use Knowledge Bases
 
-When at least one knowledge group exists in your organization, AI agents in Player sessions automatically gain access to a **Knowledge Base Agent** teammate. This specialist agent can:
+When at least one knowledge group exists in your organization, AI agents in Channels and Threads automatically gain access to a **Knowledge Base Agent** teammate. This specialist agent can:
 
 - **List available groups** — See which knowledge bases are available
 - **List group documents** — Enumerate documents within a specific group

--- a/features/mcp-server.mdx
+++ b/features/mcp-server.mdx
@@ -26,7 +26,7 @@ Example:
 @playerzero How does user authentication work in this codebase?
 ```
 
-**stop_player**: Stop a running Player that is stuck or no longer needed
+**stop_player**: Stop a running Player (thread) that is stuck or no longer needed
 ```
 @playerzero stop_player playerId="<player-id>"
 ```

--- a/features/monitors.mdx
+++ b/features/monitors.mdx
@@ -133,11 +133,11 @@ When a monitor fails, you can start an interactive debugging session to investig
 1. Open the monitor detail panel and find the failed result in the result timeline
 2. Click **Investigate with Player** next to the verdict
 3. Select a **project** to run the investigation in
-4. A new Player session opens with the monitor's context pre-loaded — including the monitor title, condition, and the evaluation's reasoning
+4. A new Channel opens with the monitor's context pre-loaded — including the monitor title, condition, and the evaluation's reasoning
 
 If an investigation already exists for that result, clicking the button opens the existing session instead of creating a duplicate.
 
-Investigation sessions show the monitor origin in the Player thread, with a link back to the monitor result. Monitor-triggered Players also appear with an activity indicator in the workflow inbox.
+Investigation sessions show the monitor origin in the Player thread, with a link back to the monitor result. Monitor-triggered Channels also appear with an activity indicator in the workflow inbox.
 
 ---
 
@@ -153,7 +153,7 @@ To configure a workflow trigger:
 
 When the monitor fails:
 
-- **Workflow started** — A new workflow Player is created and starts processing from the configured stage
+- **Workflow started** — A new workflow Channel is created and starts processing from the configured stage
 - **Workflow skipped** — A workflow was already started in the last hour for this monitor, so the run is skipped to avoid duplicates
 - **No workflow** — No workflow stage is configured
 - **Workflow failed** — Something went wrong when trying to start the workflow

--- a/features/playbooks.mdx
+++ b/features/playbooks.mdx
@@ -28,9 +28,9 @@ Each playbook includes:
 | **Category** | Organize by type. Your organization's category list is customizable — defaults include Documentation, Engineering, Go To Market/Sales, Investigation, Product, Quality Assurance (QA), SRE, Support, and Triage. Admins can add or remove categories from **Organization Settings → Playbooks**. |
 | **Tags** | Custom labels for filtering and search |
 
-### From an AI Player Conversation
+### From a PlayerZero Thread
 
-You can also create a playbook from an AI Player conversation:
+You can also create a playbook from a PlayerZero thread:
 
 1. Hover over any assistant message to reveal the **playbook icon** (library icon)
 2. Choose **From this message** to base the playbook on that specific response, or **From full chat** to capture the overall conversation pattern
@@ -41,7 +41,7 @@ You can also create a playbook from an AI Player conversation:
 
 ## Using Playbooks
 
-There are two ways to use a playbook when starting or continuing a Player conversation:
+There are two ways to use a playbook when starting or continuing a thread:
 
 <AccordionGroup>
 
@@ -90,7 +90,7 @@ Use the sort dropdown to change the order of your playbook list:
 - **Most used** — Playbooks with the highest usage count appear first
 - **Least used** — Playbooks with the lowest usage count appear first
 
-Usage is tracked automatically each time a playbook is selected in a chat input, branch investigation, or new Player creation. The detail panel shows each playbook's total usage count.
+Usage is tracked automatically each time a playbook is selected in a chat input, branch investigation, or new thread creation. The detail panel shows each playbook's total usage count.
 
 ### Version History
 


### PR DESCRIPTION
Continue the Channels and Multiworkflow terminology migration on the pages not covered by the feature-page pass. Where "Player" referred to an individual agent conversation, it now reads "thread" (or "Player thread" on integration pages for clarity); where it referred to a unit of work created or triggered by a workflow, API trigger, monitor, or an integration start action, it now reads "Channel". The "AI Players" product name, the AI Player overview links, and the stop_player tool identifier are preserved.

Covers the connector pages (Azure DevOps, Datadog, Jira, remote MCP servers), the Chrome extension pages, API Triggers, Knowledge Bases, Monitors, Code Simulations, and Playbooks.